### PR TITLE
fix: improve CI workflows and issue triage automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches: [main]
 
 permissions:
   contents: read
@@ -46,5 +44,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/gateway/coverage/lcov.info,packages/sdks/typescript/coverage/lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -39,7 +39,7 @@ jobs:
             - priority:low: Low priority
 
             Steps:
-            1. Use `gh issue view ${{ github.event.issue.number }}` to read the issue
+            1. Use `gh issue view ${{ github.event.issue.number }} --json title,body,labels,comments` to read the issue
             2. Analyze the issue title and body to determine:
                - Type of issue (bug, enhancement, documentation, question)
                - Priority level based on impact and urgency
@@ -49,3 +49,4 @@ jobs:
 
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowedTools "Bash(gh issue:*)"'

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: "node",
+		testTimeout: 10000,
 		setupFiles: ["./__tests__/setup.ts"],
 		include: ["__tests__/**/*.test.ts"],
 		exclude: ["__tests__/e2e/**/*.test.ts"],


### PR DESCRIPTION
## Summary

- Add `CODECOV_TOKEN` to codecov-action for protected branch uploads (Closes #8)
- Remove `push` trigger to prevent duplicate CI runs on PR merge (Closes #9)
- Add `--allowedTools` for `gh issue` commands in issue-triage workflow (Closes #10)
- Use `--json` flag for `gh issue view` to avoid GraphQL errors

## Test plan

- [ ] Verify codecov upload works on next PR (after merging)
- [ ] Confirm CI only runs once per PR (no duplicate on merge)
- [ ] Test issue triage workflow on a new issue - should auto-label without manual approval