### PR TITLE
feat: add SDK integration tests with real HTTP requests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "zod": "3.25.76",
       },
       "devDependencies": {
+        "@pattern-zones-co/koine-sdk": "workspace:*",
         "@types/express": "5.0.6",
         "@types/node": "25.0.2",
         "@types/supertest": "6.0.3",

--- a/packages/gateway/__tests__/integration/sdk.integration.test.ts
+++ b/packages/gateway/__tests__/integration/sdk.integration.test.ts
@@ -51,12 +51,14 @@ describe("SDK Integration Tests", () => {
 	const baseUrl = `http://localhost:${TEST_PORT}`;
 
 	// SDK functions (imported dynamically)
-	let generateText: typeof import("@pattern-zones-co/koine-sdk").generateText;
-	let generateObject: typeof import(
-		"@pattern-zones-co/koine-sdk",
-	).generateObject;
-	let streamText: typeof import("@pattern-zones-co/koine-sdk").streamText;
-	let KoineError: typeof import("@pattern-zones-co/koine-sdk").KoineError;
+	// biome-ignore lint/suspicious/noExplicitAny: assigned from dynamic import
+	let generateText: any;
+	// biome-ignore lint/suspicious/noExplicitAny: assigned from dynamic import
+	let generateObject: any;
+	// biome-ignore lint/suspicious/noExplicitAny: assigned from dynamic import
+	let streamText: any;
+	// biome-ignore lint/suspicious/noExplicitAny: assigned from dynamic import
+	let KoineError: any;
 
 	beforeAll(async () => {
 		// Import SDK

--- a/packages/gateway/__tests__/integration/sdk.integration.test.ts
+++ b/packages/gateway/__tests__/integration/sdk.integration.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Integration tests for Koine SDK with real HTTP requests.
+ *
+ * Tests SDK → HTTP → Gateway flow with mocked CLI subprocess.
+ * The SDK makes real fetch() calls (NOT mocked) to the gateway.
+ * The CLI subprocess is mocked for deterministic responses.
+ */
+
+import { spawn } from "node:child_process";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { z } from "zod";
+import {
+	createCliResultJson,
+	createMockChildProcess,
+	createSSEEvent,
+	createStreamAssistantMessage,
+	createStreamResultMessage,
+} from "../helpers.js";
+
+// Set env vars BEFORE any gateway imports (using vi.hoisted for earliest execution)
+const TEST_API_KEY = vi.hoisted(() => {
+	const key = "sdk-integration-test-key-12345";
+	process.env.CLAUDE_CODE_WRAPPER_API_KEY = key;
+	// Use a specific port unlikely to conflict with other services
+	process.env.PORT = "45123";
+	return key;
+});
+
+// Mock CLI subprocess for deterministic responses
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+const mockSpawn = vi.mocked(spawn);
+
+// Import SDK after env vars are set
+// Using dynamic import to ensure mocks and env vars are in place
+const sdkImport = vi.hoisted(async () => {
+	const sdk = await import("@pattern-zones-co/koine-sdk");
+	return sdk;
+});
+
+describe("SDK Integration Tests", () => {
+	const TEST_PORT = 45123;
+	const baseUrl = `http://localhost:${TEST_PORT}`;
+
+	// SDK functions (imported dynamically)
+	let generateText: typeof import("@pattern-zones-co/koine-sdk").generateText;
+	let generateObject: typeof import(
+		"@pattern-zones-co/koine-sdk",
+	).generateObject;
+	let streamText: typeof import("@pattern-zones-co/koine-sdk").streamText;
+	let KoineError: typeof import("@pattern-zones-co/koine-sdk").KoineError;
+
+	beforeAll(async () => {
+		// Import SDK
+		const sdk = await import("@pattern-zones-co/koine-sdk");
+		generateText = sdk.generateText;
+		generateObject = sdk.generateObject;
+		streamText = sdk.streamText;
+		KoineError = sdk.KoineError;
+
+		// Import gateway to start the server (after env vars and mocks are set)
+		// The server starts listening when the module is imported
+		await import("../../src/index.js");
+
+		// Give the server a moment to start
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	const getConfig = () => ({
+		baseUrl,
+		timeout: 30_000,
+		authKey: TEST_API_KEY,
+	});
+
+	describe("generateText", () => {
+		it("makes real HTTP request and returns text response", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const promise = generateText(getConfig(), {
+				prompt: "Hello",
+			});
+
+			// Simulate CLI response after a short delay
+			setTimeout(() => {
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(
+						createCliResultJson({
+							result: "Hello from Claude!",
+							total_tokens_in: 10,
+							total_tokens_out: 5,
+						}),
+					),
+				);
+				mockProc.exitCode = 0;
+				mockProc.emit("close", 0, null);
+			}, 50);
+
+			const result = await promise;
+
+			expect(result.text).toBe("Hello from Claude!");
+			expect(result.usage.inputTokens).toBe(10);
+			expect(result.usage.outputTokens).toBe(5);
+			expect(result.usage.totalTokens).toBe(15);
+			expect(result.sessionId).toBeDefined();
+		});
+
+		it("includes system prompt in request", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const promise = generateText(getConfig(), {
+				system: "You are a helpful assistant.",
+				prompt: "Hello",
+			});
+
+			setTimeout(() => {
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(createCliResultJson({ result: "Hi there!" })),
+				);
+				mockProc.exitCode = 0;
+				mockProc.emit("close", 0, null);
+			}, 50);
+
+			const result = await promise;
+
+			expect(result.text).toBe("Hi there!");
+			// Verify system prompt was passed to CLI
+			expect(mockSpawn).toHaveBeenCalled();
+			const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+			expect(spawnArgs).toContain("--system-prompt");
+		});
+
+		it("throws KoineError on authentication failure", async () => {
+			const badConfig = {
+				...getConfig(),
+				authKey: "wrong-api-key",
+			};
+
+			await expect(
+				generateText(badConfig, { prompt: "test" }),
+			).rejects.toBeInstanceOf(KoineError);
+		});
+	});
+
+	describe("generateObject", () => {
+		it("validates response against Zod schema", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const personSchema = z.object({
+				name: z.string(),
+				age: z.number(),
+			});
+
+			const promise = generateObject(getConfig(), {
+				prompt: "Generate a person",
+				schema: personSchema,
+			});
+
+			setTimeout(() => {
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(
+						createCliResultJson({
+							result: '{"name": "Alice", "age": 30}',
+						}),
+					),
+				);
+				mockProc.exitCode = 0;
+				mockProc.emit("close", 0, null);
+			}, 50);
+
+			const result = await promise;
+
+			expect(result.object).toEqual({ name: "Alice", age: 30 });
+			expect(result.rawText).toBe('{"name": "Alice", "age": 30}');
+			expect(result.usage).toBeDefined();
+			expect(result.sessionId).toBeDefined();
+		});
+
+		it("handles complex nested schemas", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const addressSchema = z.object({
+				user: z.object({
+					name: z.string(),
+					address: z.object({
+						street: z.string(),
+						city: z.string(),
+					}),
+				}),
+			});
+
+			const promise = generateObject(getConfig(), {
+				prompt: "Generate a user with address",
+				schema: addressSchema,
+			});
+
+			setTimeout(() => {
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(
+						createCliResultJson({
+							result: JSON.stringify({
+								user: {
+									name: "Bob",
+									address: { street: "123 Main St", city: "Springfield" },
+								},
+							}),
+						}),
+					),
+				);
+				mockProc.exitCode = 0;
+				mockProc.emit("close", 0, null);
+			}, 50);
+
+			const result = await promise;
+
+			expect(result.object.user.name).toBe("Bob");
+			expect(result.object.user.address.city).toBe("Springfield");
+		});
+	});
+
+	describe("streamText", () => {
+		it("streams text chunks via SSE", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const promise = streamText(getConfig(), {
+				prompt: "Count to 3",
+			});
+
+			// Simulate streaming response using newline-delimited JSON (NDJSON)
+			// Each JSON object must end with a newline for the gateway's line parser
+			setTimeout(() => {
+				// Text chunks (assistant messages with newlines)
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(`${createStreamAssistantMessage("One ")}\n`),
+				);
+			}, 30);
+
+			setTimeout(() => {
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(`${createStreamAssistantMessage("Two ")}\n`),
+				);
+			}, 60);
+
+			setTimeout(() => {
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(`${createStreamAssistantMessage("Three")}\n`),
+				);
+			}, 90);
+
+			setTimeout(() => {
+				// Result event (with newline)
+				mockProc.stdout.emit(
+					"data",
+					Buffer.from(
+						`${createStreamResultMessage({ session_id: "stream-session-123" })}\n`,
+					),
+				);
+				mockProc.exitCode = 0;
+				mockProc.emit("close", 0, null);
+			}, 120);
+
+			const result = await promise;
+
+			// Collect all text chunks
+			const chunks: string[] = [];
+			const reader = result.textStream.getReader();
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				chunks.push(value);
+			}
+
+			// Verify streaming worked
+			expect(chunks.length).toBeGreaterThan(0);
+
+			// Verify final text
+			const text = await result.text;
+			expect(text).toBe(chunks.join(""));
+
+			// Verify usage
+			const usage = await result.usage;
+			expect(usage.inputTokens).toBe(10);
+			expect(usage.outputTokens).toBe(15);
+
+			// Verify session ID - the gateway sends session event first, then result event updates it
+			const sessionId = await result.sessionId;
+			expect(sessionId).toBeDefined();
+		});
+	});
+
+	describe("error handling", () => {
+		it("handles CLI timeout gracefully", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const shortTimeoutConfig = {
+				...getConfig(),
+				timeout: 100, // Very short timeout
+			};
+
+			// Don't emit any response - let it timeout
+			await expect(
+				generateText(shortTimeoutConfig, { prompt: "test" }),
+			).rejects.toThrow();
+		});
+
+		it("handles CLI errors", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const promise = generateText(getConfig(), {
+				prompt: "test",
+			});
+
+			setTimeout(() => {
+				mockProc.stderr.emit("data", Buffer.from("CLI error occurred"));
+				mockProc.exitCode = 1;
+				mockProc.emit("close", 1, null);
+			}, 50);
+
+			await expect(promise).rejects.toBeInstanceOf(KoineError);
+		});
+	});
+});

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -20,6 +20,7 @@
 		"zod": "3.25.76"
 	},
 	"devDependencies": {
+		"@pattern-zones-co/koine-sdk": "workspace:*",
 		"@types/express": "5.0.6",
 		"@types/node": "25.0.2",
 		"@types/uuid": "10.0.0",

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -84,10 +84,11 @@ app.use(
 	},
 );
 
-// Start server
-app.listen(PORT, () => {
+// Start server and export for test cleanup
+const server = app.listen(PORT, () => {
 	logger.info(`Claude Code Wrapper listening on port ${PORT}`);
 	logger.info("API key authentication: enabled (required)");
 });
 
+export { server };
 export default app;


### PR DESCRIPTION
## Summary
- Add integration tests that exercise the TypeScript SDK against a locally running gateway server
- SDK makes real `fetch()` calls (NOT mocked) while CLI subprocess is mocked for deterministic responses
- Tests run as part of the default test suite - no special CI config needed

## Test Coverage
- `generateText` - real HTTP requests, system prompts, auth errors
- `generateObject` - Zod schema validation, complex nested schemas  
- `streamText` - SSE streaming chunks
- Error handling - CLI timeout, CLI failures

## Changes
- `packages/gateway/__tests__/integration/sdk.integration.test.ts` - new test file (8 tests)
- `packages/gateway/package.json` - add SDK as dev dependency

## Test Plan
- [x] All 72 gateway tests pass (`bun run test:run`)
- [x] Pre-commit hooks pass