### PR TITLE
docs: restructure documentation for Docker-first deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Koine turns Claude Code into a programmable inference layer. Use it to:
 >
 > Koine supports two authentication methods with **different terms**:
 >
-> - **OAuth tokens** (Claude Pro/Max) — subscription plans may restrict commercial use, automation, and public exposure. * See [Anthropic's Terms of Service](https://www.anthropic.com/legal/consumer-terms).
+> - **OAuth tokens** (Claude Pro/Max) — subscription plans may restrict commercial use, automation, and public exposure. See [Anthropic's Terms of Service](https://www.anthropic.com/legal/consumer-terms).
 > - **API keys** (Anthropic API) — pay-per-token with different allowable use cases
 >
 > **You are responsible for compliance.**

--- a/README.md
+++ b/README.md
@@ -2,380 +2,67 @@
 
 An HTTP gateway that exposes [Claude Code CLI](https://github.com/anthropics/claude-code) as a REST API, plus a TypeScript SDK for easy integration.
 
-> Named after **koine** — the common tongue that connected the ancient Mediterranean — Koine translates protocols and manages requests so your apps can use Claude Code CLI just like you.
+> **Koine** (pronounced /kɔɪˈneɪ/, "koy-NAY") — named after the common Greek dialect that connected the ancient Mediterranean. Koine translates protocols and manages requests so your apps can use Claude Code CLI just like you.
+
+## Why Koine?
+
+Koine turns Claude Code into a programmable inference layer. Use it to:
+
+- **Orchestrate AI-powered services** — connect Koine to your services via VPN or Docker networks
+- **Build agentic workflows** — chain Claude Code calls with structured output and session management
+- **Extend capabilities** — add custom skills, slash commands, and domain-specific context
+
+### Power and Responsibility
+
+> [!CAUTION]
+> **This is both powerful and dangerous.**
+>
+> Claude Code has full access to the tools you give it — file system, shell, network. When exposed through Koine, your applications gain that same power.
+>
+> **Docker deployment is critical.** Running in a container restricts Claude to the container user's permissions and filesystem, providing essential isolation.
+
+### Terms of Service
+
+> [!WARNING]
+> **Review Anthropic's Terms before deploying.**
+>
+> Koine supports two authentication methods with **different terms**:
+>
+> - **OAuth tokens** (Claude Pro/Max) — subscription plans may restrict commercial use, automation, and public exposure. * See [Anthropic's Terms of Service](https://www.anthropic.com/legal/consumer-terms).
+> - **API keys** (Anthropic API) — pay-per-token with different allowable use cases
+>
+> **You are responsible for compliance.
+
+### Deployment Best Practices
+
+- **Do not expose your endpoints to public use** if using OAuth — this likely violates Anthropic's Terms
+- **Use Docker** — containers provide critical security isolation
+- **Run on internal networks** — VPN or Docker networks are ideal for service-to-service communication
+- **Authenticate all requests** — the gateway requires an API key separate from Claude authentication
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](docs/README.md) | Installation and setup |
+| [API Reference](docs/api-reference.md) | REST endpoints |
+| [SDK Guide](docs/sdk-guide.md) | TypeScript SDK |
+| [Docker Deployment](docs/docker-deployment.md) | Production deployment |
+| [Skills & Commands](docs/skills-and-commands.md) | Extending Claude Code |
+| [Environment Variables](docs/environment-variables.md) | Configuration |
+| [Architecture](docs/architecture.md) | System design |
 
 ## Packages
 
 | Package | Description |
 |---------|-------------|
-| `@patternzones/koine` | HTTP gateway server wrapping Claude Code CLI |
-| `@patternzones/koine-sdk` | TypeScript SDK for gateway clients |
-
-> [!WARNING]
-> **Review Anthropic's Terms of Service**
->
-> This gateway supports two authentication methods for Claude CLI:
-> - **Subscription plans** (Claude Pro/Max) via OAuth token
-> - **API keys** via Anthropic API
->
-> These have **different terms of use and allowable applications**. Subscription plans may have restrictions on commercial use, automation, or other use cases that do not apply to API key usage.
->
-> **You are responsible for reviewing and complying with [Anthropic's Terms of Service](https://www.anthropic.com/legal/consumer-terms) and the specific terms of your subscription or API agreement before using this gateway.**
-
-## Overview
-
-Koine provides:
-
-- **REST API endpoints** for text generation, object extraction, and streaming
-- **Session management** for multi-turn conversations
-- **Health monitoring** with CLI availability checks
-- **Extensible skills system** for domain-specific capabilities
-- **Docker deployment** with hardened security configuration
-- **TypeScript SDK** for type-safe client integration
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│  Your Application                                                       │
-│  (Using SDK or HTTP client)                                             │
-└─────────────────────────────────────────────────────────────────────────┘
-                            │
-                            ▼ HTTP REST API
-┌─────────────────────────────────────────────────────────────────────────┐
-│  Koine (this service)                                                   │
-│  ┌─────────────────────────────────────────────────────────────────────┐│
-│  │ Core HTTP Server (Express)                                          ││
-│  │ - /generate-text    → Text generation                               ││
-│  │ - /generate-object  → Structured object extraction                  ││
-│  │ - /stream           → Server-Sent Events streaming                  ││
-│  │ - /health           → Health check with CLI status                  ││
-│  └─────────────────────────────────────────────────────────────────────┘│
-│                           │                                             │
-│                           ▼ Subprocess                                  │
-│  ┌─────────────────────────────────────────────────────────────────────┐│
-│  │ Claude Code CLI                                                     ││
-│  │ + Skills (loaded from claude-assets/)                               ││
-│  └─────────────────────────────────────────────────────────────────────┘│
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
-## Project Structure
-
-```
-koine/
-├── packages/
-│   ├── gateway/                     # HTTP gateway server
-│   │   ├── src/
-│   │   │   ├── index.ts             # Express app setup, auth middleware
-│   │   │   ├── cli.ts               # Claude CLI subprocess management
-│   │   │   ├── types.ts             # Request/response type definitions
-│   │   │   ├── logger.ts            # Logging utilities
-│   │   │   └── routes/
-│   │   │       ├── generate.ts      # /generate-text and /generate-object
-│   │   │       ├── stream.ts        # /stream (SSE streaming)
-│   │   │       └── health.ts        # /health endpoint
-│   │   └── __tests__/
-│   └── sdks/
-│       └── typescript/              # TypeScript client SDK
-│           ├── src/
-│           │   ├── client.ts        # HTTP client functions
-│           │   ├── types.ts         # Type definitions
-│           │   ├── errors.ts        # Custom error classes
-│           │   └── index.ts         # Public exports
-│           └── __tests__/
-├── claude-assets/                   # Skills and commands for Docker
-│   ├── skills/
-│   └── commands/
-├── Dockerfile                       # Hardened container build
-└── docker-compose.yml               # Docker deployment example
-```
-
-## Quick Start
-
-### Using the SDK
-
-```typescript
-import { generateText, KoineConfig } from '@patternzones/koine-sdk';
-
-const config: KoineConfig = {
-  baseUrl: 'http://localhost:3100',
-  timeout: 300000,
-  authKey: 'your-api-key',
-  model: 'sonnet',
-};
-
-const result = await generateText(config, {
-  prompt: 'Hello, how are you?',
-  system: 'You are a helpful assistant.',
-});
-
-console.log(result.text);
-console.log(result.usage);
-```
-
-### Streaming
-
-```typescript
-import { streamText } from '@patternzones/koine-sdk';
-
-const result = await streamText(config, {
-  prompt: 'Write a short story',
-});
-
-// Stream text chunks as they arrive
-for await (const chunk of result.textStream) {
-  process.stdout.write(chunk);
-}
-
-// Get final results
-const fullText = await result.text;
-const usage = await result.usage;
-```
-
-### Structured Output
-
-```typescript
-import { generateObject } from '@patternzones/koine-sdk';
-import { z } from 'zod';
-
-const PersonSchema = z.object({
-  name: z.string(),
-  age: z.number(),
-  email: z.string().email(),
-});
-
-const result = await generateObject(config, {
-  prompt: 'Extract person info: John is 30 years old, email: john@example.com',
-  schema: PersonSchema,
-});
-
-console.log(result.object); // { name: "John", age: 30, email: "john@example.com" }
-```
-
-## API Reference
-
-### Authentication
-
-All endpoints (except `/health`) require Bearer token authentication:
-
-```bash
-curl -H "Authorization: Bearer YOUR_API_KEY" http://localhost:3100/generate-text
-```
-
-### `POST /generate-text`
-
-Generate text from a prompt.
-
-**Request:**
-```json
-{
-  "prompt": "Explain quantum computing in simple terms",
-  "system": "You are a helpful science teacher",
-  "sessionId": "optional-session-id",
-  "model": "sonnet"
-}
-```
-
-**Response:**
-```json
-{
-  "text": "Quantum computing is...",
-  "usage": {
-    "inputTokens": 25,
-    "outputTokens": 150,
-    "totalTokens": 175
-  },
-  "sessionId": "session-uuid"
-}
-```
-
-### `POST /generate-object`
-
-Extract structured data using a JSON schema.
-
-**Request:**
-```json
-{
-  "prompt": "Extract the person's name and age from: John is 30 years old",
-  "schema": {
-    "type": "object",
-    "properties": {
-      "name": { "type": "string" },
-      "age": { "type": "number" }
-    }
-  }
-}
-```
-
-**Response:**
-```json
-{
-  "object": { "name": "John", "age": 30 },
-  "rawText": "{\"name\": \"John\", \"age\": 30}",
-  "usage": { "inputTokens": 40, "outputTokens": 20, "totalTokens": 60 },
-  "sessionId": "session-uuid"
-}
-```
-
-### `POST /stream`
-
-Stream responses via Server-Sent Events (SSE).
-
-**Request:**
-```json
-{
-  "prompt": "Write a short story about a robot",
-  "system": "You are a creative writer"
-}
-```
-
-**Response (SSE events):**
-```
-event: session
-data: {"sessionId": "session-uuid"}
-
-event: text
-data: {"text": "Once upon"}
-
-event: text
-data: {"text": " a time..."}
-
-event: result
-data: {"sessionId": "session-uuid", "usage": {...}}
-
-event: done
-data: {"code": 0, "signal": null}
-```
-
-### `GET /health`
-
-Health check endpoint (no authentication required).
-
-**Response:**
-```json
-{
-  "status": "healthy",
-  "cli": {
-    "available": true,
-    "version": "1.0.34"
-  }
-}
-```
-
-## Environment Variables
-
-### Required
-
-| Variable | Description |
-|----------|-------------|
-| `CLAUDE_CODE_GATEWAY_API_KEY` | Bearer token for authenticating API requests |
-
-### Claude Authentication (one required)
-
-| Variable | Description |
-|----------|-------------|
-| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (for Claude Max subscribers) |
-| `ANTHROPIC_API_KEY` | API key (used if OAuth token not present) |
-
-### Optional
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GATEWAY_PORT` | `3100` | HTTP server port |
-
-## Development
-
-### Prerequisites
-
-- Bun >= 1.1
-- Claude Code CLI installed (`bun install -g @anthropic-ai/claude-code`)
-
-### Setup
-
-```bash
-# Install dependencies
-bun install
-
-# Set required environment variables
-cp .env.example .env
-# Edit .env with your values
-
-# Run gateway in development mode
-bun dev
-
-# Run tests
-bun test
-
-# Build all packages
-bun run build
-```
-
-## Docker Deployment
-
-### Using Docker Compose
-
-```bash
-# Copy and edit environment file
-cp .env.example .env
-
-# Start the gateway
-docker compose up -d gateway
-
-# Check health
-curl http://localhost:3100/health
-```
-
-### Build and Run Manually
-
-```bash
-# Build
-docker build -t koine .
-
-# Run
-docker run -d \
-  -p 3100:3100 \
-  -e CLAUDE_CODE_GATEWAY_API_KEY=your-api-key \
-  -e ANTHROPIC_API_KEY=your-anthropic-key \
-  koine
-```
-
-### Security Features
-
-The Docker image includes several hardening measures:
-
-- Multi-stage build (smaller attack surface)
-- Non-root user execution (`bun` user, UID 1000)
-- Minimal base image (Bun slim ~100MB)
-- Security options: `no-new-privileges`, `cap_drop: ALL`
-- Health check endpoint
-- Read-only filesystem with tmpfs for temporary files
-
-## Skills System
-
-Claude Code supports **skills** - markdown files that teach Claude how to use domain-specific tools. Skills are placed in `claude-assets/skills/` and copied into the Docker container at build time.
-
-### Adding Custom Skills
-
-1. Create a skill directory: `claude-assets/skills/your-skill-name/`
-2. Add a `SKILL.md` file with:
-   - YAML frontmatter (`name`, `description`, `allowed-tools`)
-   - Instructions for Claude on when and how to use the skill
-   - API documentation, examples, and best practices
-
-## Error Codes
-
-| Code | Description |
-|------|-------------|
-| `TIMEOUT_ERROR` | CLI execution timed out |
-| `CLI_EXIT_ERROR` | CLI exited with non-zero code |
-| `SPAWN_ERROR` | Failed to spawn CLI process |
-| `PARSE_ERROR` | Failed to parse CLI output |
+| [koine](packages/gateway) | HTTP gateway (Docker only, not on npm) |
+| [@patternzones/koine-sdk](https://www.npmjs.com/package/@patternzones/koine-sdk) | TypeScript SDK |
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+See [LICENSE](LICENSE) for details (AGPL-3.0).
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and roadmap.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Koine turns Claude Code into a programmable inference layer. Use it to:
 > - **OAuth tokens** (Claude Pro/Max) — subscription plans may restrict commercial use, automation, and public exposure. * See [Anthropic's Terms of Service](https://www.anthropic.com/legal/consumer-terms).
 > - **API keys** (Anthropic API) — pay-per-token with different allowable use cases
 >
-> **You are responsible for compliance.
+> **You are responsible for compliance.**
 
 ### Deployment Best Practices
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 name: koine
 
 services:
-  gateway:
+  koine:
     build:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "${GATEWAY_PORT:-3100}:3100"
+      - "127.0.0.1:${GATEWAY_PORT:-3100}:3100"
     environment:
       PORT: 3100
       # HOME required for Claude CLI to find its config directory

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,58 @@
+# Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [API Reference](api-reference.md) | REST endpoints |
+| [SDK Guide](sdk-guide.md) | TypeScript SDK |
+| [Docker Deployment](docker-deployment.md) | Production deployment |
+| [Skills & Commands](skills-and-commands.md) | Extending Claude Code |
+| [Environment Variables](environment-variables.md) | Configuration |
+| [Architecture](architecture.md) | System design |
+
+## Getting Started
+
+```bash
+git clone https://github.com/pattern-zones-co/koine.git
+cd koine
+
+cp .env.example .env
+# Edit .env with your keys
+
+docker compose up -d koine
+```
+
+Verify it's running:
+
+```bash
+curl http://localhost:3100/health
+```
+
+### Usage
+
+#### curl
+
+```bash
+curl -X POST http://localhost:3100/generate-text \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $CLAUDE_CODE_GATEWAY_API_KEY" \
+  -d '{"prompt": "Hello!"}'
+```
+
+#### TypeScript SDK
+
+```bash
+npm install @patternzones/koine-sdk
+```
+
+```typescript
+import { generateText } from '@patternzones/koine-sdk';
+
+const result = await generateText(
+  { baseUrl: 'http://localhost:3100', authKey: 'your-api-key' },
+  { prompt: 'Hello!' }
+);
+
+console.log(result.text);
+```
+
+See the [SDK Guide](sdk-guide.md) for streaming and structured output.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,25 @@
+# API Reference
+
+> **TODO**: Generate OpenAPI spec from Zod schemas. See [#17](https://github.com/pattern-zones-co/koine/issues/17).
+
+## Authentication
+
+All endpoints except `/health` require Bearer token authentication:
+
+```bash
+curl -H "Authorization: Bearer $CLAUDE_CODE_GATEWAY_API_KEY" \
+  http://localhost:3100/generate-text
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check (no auth) |
+| POST | `/generate-text` | Generate text |
+| POST | `/generate-object` | Extract structured JSON |
+| POST | `/stream` | Stream via SSE |
+
+## Sessions
+
+Omit `sessionId` to start new. Include previous `sessionId` to continue conversation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,47 @@
+# Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Your Application (SDK or HTTP client)                                  │
+└─────────────────────────────────────────────────────────────────────────┘
+                            │
+                            ▼ HTTP REST API
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Koine Gateway (Express)                                                │
+│  ┌─────────────────────────────────────────────────────────────────────┐│
+│  │ /generate-text    → Text generation                                 ││
+│  │ /generate-object  → Structured JSON extraction                      ││
+│  │ /stream           → Server-Sent Events                              ││
+│  │ /health           → Health check                                    ││
+│  └─────────────────────────────────────────────────────────────────────┘│
+│                           │ Subprocess                                  │
+│  ┌─────────────────────────────────────────────────────────────────────┐│
+│  │ Claude Code CLI + Skills                                            ││
+│  └─────────────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Project Structure
+
+```
+koine/
+├── packages/
+│   ├── gateway/                     # HTTP gateway server
+│   │   └── src/
+│   │       ├── index.ts             # Express app, auth middleware
+│   │       ├── cli.ts               # Claude CLI subprocess
+│   │       ├── types.ts             # Request/response types
+│   │       └── routes/
+│   │           ├── generate.ts      # /generate-text, /generate-object
+│   │           ├── stream.ts        # /stream (SSE)
+│   │           └── health.ts        # /health
+│   └── sdks/typescript/             # TypeScript SDK
+│       └── src/
+│           ├── client.ts            # generateText, streamText, generateObject
+│           ├── types.ts             # Type definitions
+│           └── errors.ts            # KoineError
+├── claude-assets/                   # Skills and commands
+├── docs/
+├── Dockerfile
+└── docker-compose.yml
+```

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -1,0 +1,36 @@
+# Docker Deployment
+
+> **Strongly Recommended**: Docker provides critical security isolation, ensuring Claude Code operates only with container user permissions.
+
+## Quick Start
+
+```bash
+cp .env.example .env
+# Edit .env with your keys
+
+docker compose up -d koine
+curl http://localhost:3100/health
+```
+
+## Configuration
+
+See [`docker-compose.yml`](../docker-compose.yml) and [`Dockerfile`](../Dockerfile) in the repo root. These can be adapted for your orchestration setup.
+
+## Security
+
+The included configuration uses:
+
+- Multi-stage build (smaller image, no build tools in production)
+- Non-root user (`bun`, UID 1000)
+- Dropped capabilities and `no-new-privileges`
+
+These patterns are recommended for any orchestration that includes Koine.
+
+## Port Binding
+
+Bind to localhost to prevent bypassing UFW firewalls:
+
+```yaml
+ports:
+  - "127.0.0.1:3100:3100"
+```

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,30 @@
+# Environment Variables
+
+## Required
+
+| Variable | Description |
+|----------|-------------|
+| `CLAUDE_CODE_GATEWAY_API_KEY` | Bearer token for gateway API requests |
+
+## Claude Authentication (one required)
+
+| Variable | Description |
+|----------|-------------|
+| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (Claude Max). Takes precedence if both set. |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+
+## Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GATEWAY_PORT` | `3100` | HTTP server port |
+
+## Example
+
+```bash
+# .env
+CLAUDE_CODE_GATEWAY_API_KEY=your-secure-api-key
+ANTHROPIC_API_KEY=sk-ant-...
+# CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token
+GATEWAY_PORT=3100
+```

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -1,0 +1,97 @@
+# SDK Guide
+
+## Installation
+
+```bash
+npm install @patternzones/koine-sdk
+```
+
+## Configuration
+
+```typescript
+import { KoineConfig } from '@patternzones/koine-sdk';
+
+const config: KoineConfig = {
+  baseUrl: 'http://localhost:3100',
+  authKey: 'your-api-key',
+  timeout: 300000,  // optional, default 5 min
+  model: 'sonnet',  // optional default model
+};
+```
+
+## Text Generation
+
+```typescript
+import { generateText } from '@patternzones/koine-sdk';
+
+const result = await generateText(config, {
+  prompt: 'Explain quantum computing',
+  system: 'You are a helpful teacher',  // optional
+  sessionId: 'continue-conversation',   // optional
+});
+
+console.log(result.text);
+console.log(result.usage);
+console.log(result.sessionId);
+```
+
+## Streaming
+
+```typescript
+import { streamText } from '@patternzones/koine-sdk';
+
+const result = await streamText(config, {
+  prompt: 'Write a short story',
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+
+const fullText = await result.text;
+const usage = await result.usage;
+```
+
+## Structured Output
+
+```typescript
+import { generateObject } from '@patternzones/koine-sdk';
+import { z } from 'zod';
+
+const PersonSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+  email: z.string().email(),
+});
+
+const result = await generateObject(config, {
+  prompt: 'Extract: John is 30, email john@example.com',
+  schema: PersonSchema,
+});
+
+console.log(result.object);  // typed as { name: string, age: number, email: string }
+```
+
+## Error Handling
+
+```typescript
+import { KoineError } from '@patternzones/koine-sdk';
+
+try {
+  const result = await generateText(config, { prompt: 'Hello' });
+} catch (error) {
+  if (error instanceof KoineError) {
+    console.error(error.status, error.code, error.message);
+  }
+}
+```
+
+## Multi-turn Conversations
+
+```typescript
+const result1 = await generateText(config, { prompt: 'My name is Alice' });
+const result2 = await generateText(config, {
+  prompt: 'What is my name?',
+  sessionId: result1.sessionId,
+});
+```

--- a/docs/skills-and-commands.md
+++ b/docs/skills-and-commands.md
@@ -1,0 +1,36 @@
+# Skills and Commands
+
+Extend Claude Code with custom capabilities via the `claude-assets/` directory.
+
+## Use Cases
+
+- **Domain-specific knowledge** — teach Claude about your APIs, databases, or internal tools
+- **Guardrails** — constrain Claude's behavior for specific tasks
+- **Workflows** — define multi-step operations as slash commands
+
+## Loading Assets
+
+Skills and commands in `claude-assets/` are copied into the Docker image at build time:
+
+```
+claude-assets/
+├── skills/
+│   └── your-skill/
+│       └── SKILL.md
+└── commands/
+    └── your-command.md
+```
+
+Rebuild the image after adding or modifying assets:
+
+```bash
+docker compose build koine
+docker compose up -d koine
+```
+
+## Reference
+
+See Anthropic's documentation for skill and command file formats:
+
+- [Skills](https://docs.anthropic.com/en/docs/claude-code/skills)
+- [Slash Commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands)

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -1,0 +1,24 @@
+# @patternzones/koine
+
+HTTP gateway that exposes [Claude Code CLI](https://github.com/anthropics/claude-code) as a REST API.
+
+This package is not published to npm. Deploy via Docker from the [repository root](../../README.md).
+
+## Deployment
+
+```bash
+git clone https://github.com/pattern-zones-co/koine.git
+cd koine
+
+cp .env.example .env
+# Edit .env with your keys
+
+docker compose up -d koine
+```
+
+## Documentation
+
+- [Getting Started](../../docs/README.md)
+- [API Reference](../../docs/api-reference.md)
+- [Docker Deployment](../../docs/docker-deployment.md)
+- [Environment Variables](../../docs/environment-variables.md)

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@patternzones/koine",
+	"private": true,
 	"version": "1.0.0",
 	"description": "HTTP gateway service for Claude Code CLI",
 	"repository": {

--- a/packages/sdks/typescript/README.md
+++ b/packages/sdks/typescript/README.md
@@ -1,0 +1,70 @@
+# @patternzones/koine-sdk
+
+TypeScript SDK for [Koine](../../../README.md) — the HTTP gateway for Claude Code CLI.
+
+## Installation
+
+```bash
+npm install @patternzones/koine-sdk
+```
+
+## Quick Start
+
+```typescript
+import { generateText, KoineConfig } from '@patternzones/koine-sdk';
+
+const config: KoineConfig = {
+  baseUrl: 'http://localhost:3100',
+  authKey: 'your-api-key',
+};
+
+const result = await generateText(config, {
+  prompt: 'Hello, how are you?',
+});
+
+console.log(result.text);
+```
+
+## Features
+
+- **Text Generation** — `generateText()` for simple prompts
+- **Streaming** — `streamText()` with async iterators
+- **Structured Output** — `generateObject()` with Zod schema validation
+- **Type Safety** — Full TypeScript types for all requests and responses
+- **Error Handling** — `KoineError` class with status codes
+
+## API
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `generateText(config, request)` | Generate text from a prompt |
+| `streamText(config, request)` | Stream text via Server-Sent Events |
+| `generateObject(config, request)` | Extract structured data using a Zod schema |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `KoineConfig` | Client configuration (baseUrl, authKey, timeout, model) |
+| `GenerateTextRequest` | Text generation request options |
+| `GenerateTextResponse` | Text generation response with usage stats |
+| `GenerateObjectRequest` | Object extraction request with Zod schema |
+| `GenerateObjectResponse` | Object extraction response |
+| `KoineStreamResult` | Streaming result with async iterators |
+| `KoineError` | Error class with status and code |
+
+## Documentation
+
+See the [SDK Guide](../../../docs/sdk-guide.md) for:
+
+- Configuration options
+- Streaming examples
+- Structured output with Zod
+- Error handling
+- Multi-turn conversations
+
+## License
+
+[AGPL-3.0](../../../LICENSE)


### PR DESCRIPTION
## Summary

- Refocus main README on "why" with security warnings and best practices
- Create `docs/` folder with focused guides
- Emphasize VPN/Docker network deployment over public exposure
- Mark gateway package as private (Docker-only, not published to npm)

## Changes

### Main README
- Added pronunciation guide for "koine"
- Added Power and Responsibility / Terms of Service warnings
- Removed inline getting started (moved to docs/)
- Links to docs/ for detailed guides

### New docs/ structure
- `README.md` — Getting started + table of contents
- `api-reference.md` — Stub pending OpenAPI generation (#17)
- `sdk-guide.md` — TypeScript SDK usage
- `docker-deployment.md` — Security posture and port binding
- `environment-variables.md` — Configuration reference
- `skills-and-commands.md` — Use cases and loading assets
- `architecture.md` — System diagram and project structure

### Package changes
- `packages/gateway/package.json` — Added `"private": true`
- `docker-compose.yml` — Renamed service to `koine`, bind to `127.0.0.1`
- Added package READMEs for gateway and SDK

## Related

- Closes the documentation improvements discussed for initial release
- References #17 for OpenAPI spec generation