### PR TITLE
Generate OpenAPI spec from Zod schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Check OpenAPI spec is up to date
+        run: |
+          bun run --filter @patternzones/koine openapi:generate
+          if ! git diff --quiet docs/openapi.yaml; then
+            echo "Error: OpenAPI spec is out of date. Run 'bun run --filter @patternzones/koine openapi:generate' and commit the changes."
+            git diff docs/openapi.yaml
+            exit 1
+          fi
+
       - name: Test with coverage
         run: bun run test:coverage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN bun run build
 WORKDIR /app
 
 # Re-install with production deps only
-RUN rm -rf node_modules packages/gateway/node_modules && bun install --production
+# --ignore-scripts: skip prepare script (husky) since it's a dev dependency
+RUN rm -rf node_modules packages/gateway/node_modules && bun install --production --ignore-scripts
 
 # ----- Stage 2: Runtime -----
 FROM oven/bun:1.3.3-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@ FROM oven/bun:1.3.3-slim AS builder
 
 WORKDIR /app
 
-# Copy package files (root workspace + gateway package)
+# Copy package files (root workspace + all workspace packages)
 COPY package.json ./
 COPY bun.lock* ./
 COPY packages/gateway/package.json ./packages/gateway/
+COPY packages/sdks/typescript/package.json ./packages/sdks/typescript/
 
 # Install dependencies (including dev deps for build)
 # Falls back to non-frozen install if no lockfile exists

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "zod": "3.25.76",
       },
       "devDependencies": {
+        "@asteasolutions/zod-to-openapi": "7.3.4",
         "@patternzones/koine-sdk": "workspace:*",
         "@types/express": "5.0.6",
         "@types/node": "25.0.2",
@@ -29,6 +30,7 @@
         "tsx": "4.21.0",
         "typescript": "5.9.3",
         "vitest": "3.2.4",
+        "yaml": "^2.8.2",
       },
     },
     "packages/sdks/typescript": {
@@ -51,6 +53,8 @@
   },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@7.3.4", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^3.20.2" } }, "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -588,6 +592,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
+
     "p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
     "p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
@@ -745,6 +751,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
       "name": "@patternzones/koine",
       "version": "1.0.0",
       "dependencies": {
+        "@scalar/express-api-reference": "^0.8.30",
         "express": "4.22.1",
         "uuid": "11.1.0",
         "zod": "3.25.76",
@@ -237,6 +238,14 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.5", "", { "os": "win32", "cpu": "x64" }, "sha512-2NqKgZSuLH9SXBBV2dWNRCZmocgSOx8OJSdpRaEcRlIfX8YrKxUT6z0F1NpvDVhOsl190UFTRh2F2WDWWCYp3A=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.5", "", { "os": "win32", "cpu": "x64" }, "sha512-JRpZUhCfhZ4keB5v0fe02gQJy05GqboPOaxvjugW04RLSYYoB/9t2lx2u/tMs/Na/1NXfY8QYjgRljRpN+MjTQ=="],
+
+    "@scalar/core": ["@scalar/core@0.3.28", "", { "dependencies": { "@scalar/types": "0.5.4" } }, "sha512-Ka+g5P3Fe4f9lsJcBxfI+XAgwMYeZRgzIBWw1/HBrDoRmH3rV/N//410MBKEYXUw7pWpS+dZPJANZRvU5jtxhw=="],
+
+    "@scalar/express-api-reference": ["@scalar/express-api-reference@0.8.30", "", { "dependencies": { "@scalar/core": "0.3.28" } }, "sha512-hc2Feq4D73kP5zYFfxg/CeUDUz29F84iP39PwZZ0z3YWESrGRX1hmZAjcdfSMm7ViXe4ob3xJX4x7HT4/0TJQQ=="],
+
+    "@scalar/helpers": ["@scalar/helpers@0.2.4", "", {}, "sha512-G7oGybO2QXM+MIxa4OZLXaYsS9mxKygFgOcY4UOXO6xpVoY5+8rahdak9cPk7HNj8RZSt4m/BveoT8g5BtnXxg=="],
+
+    "@scalar/types": ["@scalar/types@0.5.4", "", { "dependencies": { "@scalar/helpers": "0.2.4", "nanoid": "5.1.5", "type-fest": "5.0.0", "zod": "^4.1.11" } }, "sha512-5FNQH/zx3tnERzxfpErscPHfRxLCuhncmhFYiaSz196Xi2iG1YI08BtxTV2slfT6of52epJ/MrKerarplKf9eg=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
@@ -696,6 +705,8 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "test-exclude": ["test-exclude@7.0.1", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^9.0.4" } }, "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg=="],
 
     "text-extensions": ["text-extensions@2.4.0", "", {}, "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g=="],
@@ -717,6 +728,8 @@
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-fest": ["type-fest@5.0.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-GeJop7+u7BYlQ6yQCAY1nBQiRSHR+6OdCEtd8Bwp9a3NK3+fWAVjOaPKJDteB9f6cIJ0wt4IfnScjLG450EpXA=="],
 
     "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
@@ -773,6 +786,10 @@
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@scalar/types/nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
+
+    "@scalar/types/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,545 @@
+openapi: 3.1.0
+info:
+  title: Koine Gateway API
+  version: 1.0.0
+  description: HTTP gateway service for Claude Code CLI. Provides REST endpoints for text generation, structured object generation, and streaming responses.
+  license:
+    name: AGPL-3.0
+    url: https://www.gnu.org/licenses/agpl-3.0.en.html
+  contact:
+    name: Pattern Zones Co
+    url: https://github.com/pattern-zones-co/koine
+servers:
+  - url: http://localhost:3100
+    description: Local development server
+tags:
+  - name: Health
+    description: Health check endpoints
+  - name: Generation
+    description: Text and object generation endpoints
+  - name: Streaming
+    description: Server-Sent Events streaming endpoints
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: "API key for authentication. Generate with: openssl rand -hex 32"
+  schemas:
+    GenerateTextRequest:
+      type: object
+      properties:
+        system:
+          type: string
+        prompt:
+          type: string
+        sessionId:
+          type: string
+        maxTokens:
+          type: number
+        model:
+          type: string
+        userEmail:
+          type: string
+          format: email
+      required:
+        - prompt
+    GenerateObjectRequest:
+      type: object
+      properties:
+        system:
+          type: string
+        prompt:
+          type: string
+        schema:
+          type: object
+          additionalProperties: {}
+        sessionId:
+          type: string
+        maxTokens:
+          type: number
+        model:
+          type: string
+        userEmail:
+          type: string
+          format: email
+      required:
+        - prompt
+        - schema
+    StreamRequest:
+      type: object
+      properties:
+        system:
+          type: string
+        prompt:
+          type: string
+        sessionId:
+          type: string
+        model:
+          type: string
+        userEmail:
+          type: string
+          format: email
+      required:
+        - prompt
+    UsageInfo:
+      type: object
+      properties:
+        inputTokens:
+          type: number
+        outputTokens:
+          type: number
+        totalTokens:
+          type: number
+      required:
+        - inputTokens
+        - outputTokens
+        - totalTokens
+    GenerateTextResponse:
+      type: object
+      properties:
+        text:
+          type: string
+        usage:
+          type: object
+          properties:
+            inputTokens:
+              type: number
+            outputTokens:
+              type: number
+            totalTokens:
+              type: number
+          required:
+            - inputTokens
+            - outputTokens
+            - totalTokens
+        sessionId:
+          type: string
+      required:
+        - text
+        - usage
+        - sessionId
+    GenerateObjectResponse:
+      type: object
+      properties:
+        object: {}
+        rawText:
+          type: string
+        usage:
+          type: object
+          properties:
+            inputTokens:
+              type: number
+            outputTokens:
+              type: number
+            totalTokens:
+              type: number
+          required:
+            - inputTokens
+            - outputTokens
+            - totalTokens
+        sessionId:
+          type: string
+      required:
+        - rawText
+        - usage
+        - sessionId
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+          enum: &a3
+            - VALIDATION_ERROR
+            - INTERNAL_ERROR
+            - UNKNOWN_ERROR
+            - TIMEOUT_ERROR
+            - CLI_EXIT_ERROR
+            - SPAWN_ERROR
+            - PARSE_ERROR
+        rawText:
+          type: string
+      required:
+        - error
+        - code
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: &a1
+            - healthy
+            - unhealthy
+        claudeCli:
+          type: string
+          enum: &a2
+            - available
+            - unavailable
+        timestamp:
+          type: string
+        error:
+          type: string
+      required:
+        - status
+        - claudeCli
+        - timestamp
+  parameters: {}
+paths:
+  /health:
+    get:
+      summary: Health check endpoint
+      description: Verifies the service is running and Claude CLI is accessible. No authentication required.
+      tags:
+        - Health
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: *a1
+                  claudeCli:
+                    type: string
+                    enum: *a2
+                  timestamp:
+                    type: string
+                  error:
+                    type: string
+                required:
+                  - status
+                  - claudeCli
+                  - timestamp
+        "503":
+          description: Service is unhealthy (Claude CLI unavailable)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: *a1
+                  claudeCli:
+                    type: string
+                    enum: *a2
+                  timestamp:
+                    type: string
+                  error:
+                    type: string
+                required:
+                  - status
+                  - claudeCli
+                  - timestamp
+  /generate-text:
+    post:
+      summary: Generate text response
+      description: Generates plain text response from Claude CLI.
+      tags:
+        - Generation
+      security:
+        - BearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                system:
+                  type: string
+                prompt:
+                  type: string
+                sessionId:
+                  type: string
+                maxTokens:
+                  type: number
+                model:
+                  type: string
+                userEmail:
+                  type: string
+                  format: email
+              required:
+                - prompt
+      responses:
+        "200":
+          description: Successful text generation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                  usage:
+                    type: object
+                    properties:
+                      inputTokens:
+                        type: number
+                      outputTokens:
+                        type: number
+                      totalTokens:
+                        type: number
+                    required:
+                      - inputTokens
+                      - outputTokens
+                      - totalTokens
+                  sessionId:
+                    type: string
+                required:
+                  - text
+                  - usage
+                  - sessionId
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: *a3
+                  rawText:
+                    type: string
+                required:
+                  - error
+                  - code
+        "401":
+          description: Missing authorization header
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+        "500":
+          description: Internal server error or CLI error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: *a3
+                  rawText:
+                    type: string
+                required:
+                  - error
+                  - code
+  /generate-object:
+    post:
+      summary: Generate structured JSON response
+      description: Generates structured JSON response from Claude CLI. The schema is passed in the request to instruct Claude to output valid JSON.
+      tags:
+        - Generation
+      security:
+        - BearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                system:
+                  type: string
+                prompt:
+                  type: string
+                schema:
+                  type: object
+                  additionalProperties: {}
+                sessionId:
+                  type: string
+                maxTokens:
+                  type: number
+                model:
+                  type: string
+                userEmail:
+                  type: string
+                  format: email
+              required:
+                - prompt
+                - schema
+      responses:
+        "200":
+          description: Successful object generation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  object: {}
+                  rawText:
+                    type: string
+                  usage:
+                    type: object
+                    properties:
+                      inputTokens:
+                        type: number
+                      outputTokens:
+                        type: number
+                      totalTokens:
+                        type: number
+                    required:
+                      - inputTokens
+                      - outputTokens
+                      - totalTokens
+                  sessionId:
+                    type: string
+                required:
+                  - rawText
+                  - usage
+                  - sessionId
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: *a3
+                  rawText:
+                    type: string
+                required:
+                  - error
+                  - code
+        "401":
+          description: Missing authorization header
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+        "500":
+          description: Internal server error or CLI error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: *a3
+                  rawText:
+                    type: string
+                required:
+                  - error
+                  - code
+  /stream:
+    post:
+      summary: Stream text response via SSE
+      description: "Streams Claude CLI output using Server-Sent Events (SSE). Provides real-time streaming of Claude's response with session management and usage tracking. Event types: session (session ID), text (streaming content), result (final usage stats), error (errors), done (stream complete)."
+      tags:
+        - Streaming
+      security:
+        - BearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                system:
+                  type: string
+                prompt:
+                  type: string
+                sessionId:
+                  type: string
+                model:
+                  type: string
+                userEmail:
+                  type: string
+                  format: email
+              required:
+                - prompt
+      responses:
+        "200":
+          description: SSE stream with real-time Claude CLI output
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: *a3
+                  rawText:
+                    type: string
+                required:
+                  - error
+                  - code
+        "401":
+          description: Missing authorization header
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+        "403":
+          description: Invalid API key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+webhooks: {}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15,6 +15,8 @@ servers:
 tags:
   - name: Health
     description: Health check endpoints
+  - name: Documentation
+    description: API documentation and OpenAPI specification
   - name: Generation
     description: Text and object generation endpoints
   - name: Streaming
@@ -236,6 +238,32 @@ paths:
                   - status
                   - claudeCli
                   - timestamp
+  /docs:
+    get:
+      summary: API documentation
+      description: Interactive API documentation powered by Scalar. No authentication required.
+      tags:
+        - Documentation
+      responses:
+        "200":
+          description: HTML page with interactive API documentation
+          content:
+            text/html:
+              schema:
+                type: string
+  /openapi.yaml:
+    get:
+      summary: OpenAPI specification
+      description: Raw OpenAPI 3.1 specification in YAML format. No authentication required.
+      tags:
+        - Documentation
+      responses:
+        "200":
+          description: OpenAPI specification in YAML format
+          content:
+            text/yaml:
+              schema:
+                type: string
   /generate-text:
     post:
       summary: Generate text response

--- a/packages/gateway/__tests__/integration/app.test.ts
+++ b/packages/gateway/__tests__/integration/app.test.ts
@@ -14,7 +14,7 @@ import { createCliResultJson, createMockChildProcess } from "../helpers.js";
 // Using vi.hoisted to ensure this runs at the earliest possible time
 const TEST_API_KEY = vi.hoisted(() => {
 	const key = "test-api-key-12345";
-	process.env.CLAUDE_CODE_WRAPPER_API_KEY = key;
+	process.env.CLAUDE_CODE_GATEWAY_API_KEY = key;
 	return key;
 });
 

--- a/packages/gateway/__tests__/integration/sdk.integration.test.ts
+++ b/packages/gateway/__tests__/integration/sdk.integration.test.ts
@@ -30,7 +30,7 @@ import {
 // Set env vars BEFORE any gateway imports (using vi.hoisted for earliest execution)
 const TEST_API_KEY = vi.hoisted(() => {
 	const key = "sdk-integration-test-key-12345";
-	process.env.CLAUDE_CODE_WRAPPER_API_KEY = key;
+	process.env.CLAUDE_CODE_GATEWAY_API_KEY = key;
 	// Use port 0 to let OS assign an available port (avoids conflicts in parallel runs)
 	process.env.PORT = "0";
 	return key;

--- a/packages/gateway/__tests__/openapi/generate.test.ts
+++ b/packages/gateway/__tests__/openapi/generate.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { generateOpenAPIDocument } from "../../src/openapi/index.js";
+
+describe("OpenAPI Generation", () => {
+	const doc = generateOpenAPIDocument();
+
+	it("should generate a valid OpenAPI 3.1 document", () => {
+		expect(doc.openapi).toBe("3.1.0");
+		expect(doc.info.title).toBe("Koine Gateway API");
+		expect(doc.info.version).toBe("1.0.0");
+	});
+
+	it("should include all endpoints", () => {
+		expect(doc.paths).toHaveProperty("/health");
+		expect(doc.paths).toHaveProperty("/generate-text");
+		expect(doc.paths).toHaveProperty("/generate-object");
+		expect(doc.paths).toHaveProperty("/stream");
+	});
+
+	it("should include security scheme", () => {
+		expect(doc.components?.securitySchemes).toHaveProperty("BearerAuth");
+		expect(doc.components?.securitySchemes?.BearerAuth).toEqual({
+			type: "http",
+			scheme: "bearer",
+			description:
+				"API key for authentication. Generate with: openssl rand -hex 32",
+		});
+	});
+
+	it("should include all registered schemas", () => {
+		const schemas = doc.components?.schemas;
+		expect(schemas).toHaveProperty("GenerateTextRequest");
+		expect(schemas).toHaveProperty("GenerateObjectRequest");
+		expect(schemas).toHaveProperty("StreamRequest");
+		expect(schemas).toHaveProperty("GenerateTextResponse");
+		expect(schemas).toHaveProperty("GenerateObjectResponse");
+		expect(schemas).toHaveProperty("ErrorResponse");
+		expect(schemas).toHaveProperty("HealthResponse");
+		expect(schemas).toHaveProperty("UsageInfo");
+	});
+
+	it("should require authentication for generation endpoints", () => {
+		const generateTextPath = doc.paths?.["/generate-text"]?.post;
+		const generateObjectPath = doc.paths?.["/generate-object"]?.post;
+		const streamPath = doc.paths?.["/stream"]?.post;
+
+		expect(generateTextPath?.security).toEqual([{ BearerAuth: [] }]);
+		expect(generateObjectPath?.security).toEqual([{ BearerAuth: [] }]);
+		expect(streamPath?.security).toEqual([{ BearerAuth: [] }]);
+	});
+
+	it("should not require authentication for health endpoint", () => {
+		const healthPath = doc.paths?.["/health"]?.get;
+		expect(healthPath?.security).toBeUndefined();
+	});
+
+	it("should include proper tags", () => {
+		expect(doc.tags).toContainEqual({
+			name: "Health",
+			description: "Health check endpoints",
+		});
+		expect(doc.tags).toContainEqual({
+			name: "Generation",
+			description: "Text and object generation endpoints",
+		});
+		expect(doc.tags).toContainEqual({
+			name: "Streaming",
+			description: "Server-Sent Events streaming endpoints",
+		});
+	});
+
+	it("should include server configuration", () => {
+		expect(doc.servers).toContainEqual({
+			url: "http://localhost:3100",
+			description: "Local development server",
+		});
+	});
+});

--- a/packages/gateway/__tests__/routes/docs.test.ts
+++ b/packages/gateway/__tests__/routes/docs.test.ts
@@ -1,0 +1,48 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import docsRouter from "../../src/routes/docs.js";
+
+// Create test app with just the docs router
+function createTestApp() {
+	const app = express();
+	app.use(docsRouter);
+	return app;
+}
+
+describe("Documentation Routes", () => {
+	describe("GET /openapi.yaml", () => {
+		it("returns OpenAPI spec", async () => {
+			const app = createTestApp();
+			const response = await request(app).get("/openapi.yaml");
+
+			expect(response.status).toBe(200);
+			expect(response.type).toBe("text/yaml");
+			expect(response.text).toContain("openapi: 3.1.0");
+			expect(response.text).toContain("Koine Gateway API");
+		});
+
+		it("contains all expected paths", async () => {
+			const app = createTestApp();
+			const response = await request(app).get("/openapi.yaml");
+
+			expect(response.text).toContain("/health:");
+			expect(response.text).toContain("/docs:");
+			expect(response.text).toContain("/openapi.yaml:");
+			expect(response.text).toContain("/generate-text:");
+			expect(response.text).toContain("/generate-object:");
+			expect(response.text).toContain("/stream:");
+		});
+	});
+
+	describe("GET /docs", () => {
+		it("returns Scalar documentation page", async () => {
+			const app = createTestApp();
+			const response = await request(app).get("/docs");
+
+			expect(response.status).toBe(200);
+			expect(response.type).toBe("text/html");
+			expect(response.text).toContain("Scalar");
+		});
+	});
+});

--- a/packages/gateway/__tests__/routes/generate.test.ts
+++ b/packages/gateway/__tests__/routes/generate.test.ts
@@ -80,7 +80,7 @@ describe("Generate Routes", () => {
 						session_id: "session-123",
 					}),
 				);
-			}, 10);
+			}, 50);
 
 			const res = await responsePromise;
 
@@ -107,7 +107,7 @@ describe("Generate Routes", () => {
 
 			setTimeout(() => {
 				simulateCliSuccess(mockProc, createCliResultJson({ result: "Hi!" }));
-			}, 10);
+			}, 50);
 
 			await responsePromise;
 
@@ -129,7 +129,7 @@ describe("Generate Routes", () => {
 
 			setTimeout(() => {
 				simulateCliSuccess(mockProc, createCliResultJson({ result: "Hi!" }));
-			}, 10);
+			}, 50);
 
 			await responsePromise;
 
@@ -151,7 +151,7 @@ describe("Generate Routes", () => {
 
 			setTimeout(() => {
 				simulateCliSuccess(mockProc, createCliResultJson({ result: "Hi!" }));
-			}, 10);
+			}, 50);
 
 			await responsePromise;
 
@@ -173,7 +173,7 @@ describe("Generate Routes", () => {
 
 			setTimeout(() => {
 				simulateCliError(mockProc, "Rate limit exceeded", 1);
-			}, 10);
+			}, 50);
 
 			const res = await responsePromise;
 
@@ -232,7 +232,7 @@ describe("Generate Routes", () => {
 						result: '{"name": "Alice", "age": 30}',
 					}),
 				);
-			}, 10);
+			}, 50);
 
 			const res = await responsePromise;
 
@@ -259,7 +259,7 @@ describe("Generate Routes", () => {
 						result: '```json\n{"name": "Bob"}\n```',
 					}),
 				);
-			}, 10);
+			}, 50);
 
 			const res = await responsePromise;
 
@@ -283,7 +283,7 @@ describe("Generate Routes", () => {
 						result: 'Here is the result: {"name": "Charlie"} - done!',
 					}),
 				);
-			}, 10);
+			}, 50);
 
 			const res = await responsePromise;
 
@@ -308,7 +308,7 @@ describe("Generate Routes", () => {
 						result: '["one", "two", "three"]',
 					}),
 				);
-			}, 10);
+			}, 50);
 
 			const res = await responsePromise;
 
@@ -332,7 +332,7 @@ describe("Generate Routes", () => {
 						result: "This is not valid JSON at all",
 					}),
 				);
-			}, 10);
+			}, 50);
 
 			const res = await responsePromise;
 
@@ -355,7 +355,7 @@ describe("Generate Routes", () => {
 					mockProc,
 					createCliResultJson({ result: '{"name": "Test"}' }),
 				);
-			}, 10);
+			}, 50);
 
 			await responsePromise;
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -21,7 +21,9 @@
 		"test": "vitest",
 		"test:run": "vitest run",
 		"test:coverage": "vitest run --coverage",
-		"test:e2e": "RUN_E2E_TESTS=true vitest run --config vitest.e2e.config.ts"
+		"test:e2e": "RUN_E2E_TESTS=true vitest run --config vitest.e2e.config.ts",
+		"openapi:generate": "bun run scripts/generate-openapi.ts",
+		"openapi:check": "bun run scripts/generate-openapi.ts && git diff --exit-code docs/openapi.yaml"
 	},
 	"dependencies": {
 		"express": "4.22.1",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -29,16 +29,18 @@
 		"zod": "3.25.76"
 	},
 	"devDependencies": {
+		"@asteasolutions/zod-to-openapi": "7.3.4",
 		"@patternzones/koine-sdk": "workspace:*",
 		"@types/express": "5.0.6",
 		"@types/node": "25.0.2",
-		"@types/uuid": "10.0.0",
 		"@types/supertest": "6.0.3",
+		"@types/uuid": "10.0.0",
 		"@vitest/coverage-v8": "3.2.4",
 		"supertest": "7.1.4",
 		"tsx": "4.21.0",
 		"typescript": "5.9.3",
-		"vitest": "3.2.4"
+		"vitest": "3.2.4",
+		"yaml": "^2.8.2"
 	},
 	"engines": {
 		"node": "22.21.1",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -14,9 +14,9 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"dev": "tsx watch src/index.ts",
+		"dev": "bun --env-file=../../.env tsx watch src/index.ts",
 		"build": "tsc",
-		"start": "bun run dist/index.js",
+		"start": "bun --env-file=../../.env run dist/index.js",
 		"lint": "biome check .",
 		"test": "vitest",
 		"test:run": "vitest run",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -26,6 +26,7 @@
 		"openapi:check": "bun run scripts/generate-openapi.ts && git diff --exit-code docs/openapi.yaml"
 	},
 	"dependencies": {
+		"@scalar/express-api-reference": "^0.8.30",
 		"express": "4.22.1",
 		"uuid": "11.1.0",
 		"zod": "3.25.76"

--- a/packages/gateway/scripts/generate-openapi.ts
+++ b/packages/gateway/scripts/generate-openapi.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env bun
+import { writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { stringify } from "yaml";
+import { generateOpenAPIDocument } from "../src/openapi/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outputPath = resolve(__dirname, "../../../docs/openapi.yaml");
+
+console.log("Generating OpenAPI specification...");
+
+const document = generateOpenAPIDocument();
+const yamlContent = stringify(document, { lineWidth: 0 });
+
+writeFileSync(outputPath, yamlContent, "utf-8");
+
+console.log(`OpenAPI specification written to: ${outputPath}`);

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import express, { type Application } from "express";
 import { logger } from "./logger.js";
+import docsRouter from "./routes/docs.js";
 import generateRouter from "./routes/generate.js";
 import healthRouter from "./routes/health.js";
 import streamRouter from "./routes/stream.js";
@@ -21,10 +22,14 @@ if (!WRAPPER_API_KEY) {
 // Middleware
 app.use(express.json({ limit: "10mb" }));
 
-// API key authentication (required for all routes except health check)
+// API key authentication (required for all routes except health check and docs)
 app.use((req, res, next) => {
-	// Skip auth for health check
-	if (req.path === "/health") {
+	// Skip auth for health check and documentation
+	if (
+		req.path === "/health" ||
+		req.path === "/docs" ||
+		req.path === "/openapi.yaml"
+	) {
 		next();
 		return;
 	}
@@ -60,6 +65,7 @@ app.use((req, _res, next) => {
 
 // Routes
 app.use(healthRouter);
+app.use(docsRouter);
 app.use(generateRouter);
 app.use(streamRouter);
 

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -7,13 +7,13 @@ import healthRouter from "./routes/health.js";
 import streamRouter from "./routes/stream.js";
 
 const app: Application = express();
-const PORT = process.env.PORT || 3100;
-const WRAPPER_API_KEY = process.env.CLAUDE_CODE_WRAPPER_API_KEY;
+const PORT = process.env.PORT || process.env.GATEWAY_PORT || 3100;
+const GATEWAY_API_KEY = process.env.CLAUDE_CODE_GATEWAY_API_KEY;
 
-// Require API key for security - prevents accidental exposure of wrapper service
-if (!WRAPPER_API_KEY) {
+// Require API key for security - prevents accidental exposure of gateway service
+if (!GATEWAY_API_KEY) {
 	logger.error(
-		"CLAUDE_CODE_WRAPPER_API_KEY environment variable is required. " +
+		"CLAUDE_CODE_GATEWAY_API_KEY environment variable is required. " +
 			"Generate one with: openssl rand -hex 32",
 	);
 	process.exit(1);
@@ -44,7 +44,7 @@ app.use((req, res, next) => {
 
 	// Use timing-safe comparison to prevent timing attacks
 	const tokenBuffer = Buffer.from(token);
-	const apiKeyBuffer = Buffer.from(WRAPPER_API_KEY);
+	const apiKeyBuffer = Buffer.from(GATEWAY_API_KEY);
 	const isValid =
 		tokenBuffer.length === apiKeyBuffer.length &&
 		timingSafeEqual(tokenBuffer, apiKeyBuffer);

--- a/packages/gateway/src/openapi/index.ts
+++ b/packages/gateway/src/openapi/index.ts
@@ -1,0 +1,44 @@
+import { OpenApiGeneratorV31 } from "@asteasolutions/zod-to-openapi";
+import { registry } from "./schemas.js";
+import "./paths.js"; // Side-effect: registers paths
+
+export function generateOpenAPIDocument() {
+	const generator = new OpenApiGeneratorV31(registry.definitions);
+
+	return generator.generateDocument({
+		openapi: "3.1.0",
+		info: {
+			title: "Koine Gateway API",
+			version: "1.0.0",
+			description:
+				"HTTP gateway service for Claude Code CLI. Provides REST endpoints for text generation, structured object generation, and streaming responses.",
+			license: {
+				name: "AGPL-3.0",
+				url: "https://www.gnu.org/licenses/agpl-3.0.en.html",
+			},
+			contact: {
+				name: "Pattern Zones Co",
+				url: "https://github.com/pattern-zones-co/koine",
+			},
+		},
+		servers: [
+			{
+				url: "http://localhost:3100",
+				description: "Local development server",
+			},
+		],
+		tags: [
+			{ name: "Health", description: "Health check endpoints" },
+			{
+				name: "Generation",
+				description: "Text and object generation endpoints",
+			},
+			{
+				name: "Streaming",
+				description: "Server-Sent Events streaming endpoints",
+			},
+		],
+	});
+}
+
+export { registry };

--- a/packages/gateway/src/openapi/index.ts
+++ b/packages/gateway/src/openapi/index.ts
@@ -30,6 +30,10 @@ export function generateOpenAPIDocument() {
 		tags: [
 			{ name: "Health", description: "Health check endpoints" },
 			{
+				name: "Documentation",
+				description: "API documentation and OpenAPI specification",
+			},
+			{
 				name: "Generation",
 				description: "Text and object generation endpoints",
 			},

--- a/packages/gateway/src/openapi/paths.ts
+++ b/packages/gateway/src/openapi/paths.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+import {
+	errorResponseSchema,
+	generateObjectRequestSchema,
+	generateObjectResponseSchema,
+	generateTextRequestSchema,
+	generateTextResponseSchema,
+	healthResponseSchema,
+	streamRequestSchema,
+} from "../types.js";
+import { registry } from "./schemas.js";
+
+// GET /health (no auth required)
+registry.registerPath({
+	method: "get",
+	path: "/health",
+	summary: "Health check endpoint",
+	description:
+		"Verifies the service is running and Claude CLI is accessible. No authentication required.",
+	tags: ["Health"],
+	responses: {
+		200: {
+			description: "Service is healthy",
+			content: {
+				"application/json": {
+					schema: healthResponseSchema,
+				},
+			},
+		},
+		503: {
+			description: "Service is unhealthy (Claude CLI unavailable)",
+			content: {
+				"application/json": {
+					schema: healthResponseSchema,
+				},
+			},
+		},
+	},
+});
+
+// POST /generate-text
+registry.registerPath({
+	method: "post",
+	path: "/generate-text",
+	summary: "Generate text response",
+	description: "Generates plain text response from Claude CLI.",
+	tags: ["Generation"],
+	security: [{ BearerAuth: [] }],
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: generateTextRequestSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			description: "Successful text generation",
+			content: {
+				"application/json": {
+					schema: generateTextResponseSchema,
+				},
+			},
+		},
+		400: {
+			description: "Validation error",
+			content: {
+				"application/json": {
+					schema: errorResponseSchema,
+				},
+			},
+		},
+		401: {
+			description: "Missing authorization header",
+			content: {
+				"application/json": {
+					schema: z.object({ error: z.string() }),
+				},
+			},
+		},
+		403: {
+			description: "Invalid API key",
+			content: {
+				"application/json": {
+					schema: z.object({ error: z.string() }),
+				},
+			},
+		},
+		500: {
+			description: "Internal server error or CLI error",
+			content: {
+				"application/json": {
+					schema: errorResponseSchema,
+				},
+			},
+		},
+	},
+});
+
+// POST /generate-object
+registry.registerPath({
+	method: "post",
+	path: "/generate-object",
+	summary: "Generate structured JSON response",
+	description:
+		"Generates structured JSON response from Claude CLI. The schema is passed in the request to instruct Claude to output valid JSON.",
+	tags: ["Generation"],
+	security: [{ BearerAuth: [] }],
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: generateObjectRequestSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			description: "Successful object generation",
+			content: {
+				"application/json": {
+					schema: generateObjectResponseSchema,
+				},
+			},
+		},
+		400: {
+			description: "Validation error",
+			content: {
+				"application/json": {
+					schema: errorResponseSchema,
+				},
+			},
+		},
+		401: {
+			description: "Missing authorization header",
+			content: {
+				"application/json": {
+					schema: z.object({ error: z.string() }),
+				},
+			},
+		},
+		403: {
+			description: "Invalid API key",
+			content: {
+				"application/json": {
+					schema: z.object({ error: z.string() }),
+				},
+			},
+		},
+		500: {
+			description: "Internal server error or CLI error",
+			content: {
+				"application/json": {
+					schema: errorResponseSchema,
+				},
+			},
+		},
+	},
+});
+
+// POST /stream
+registry.registerPath({
+	method: "post",
+	path: "/stream",
+	summary: "Stream text response via SSE",
+	description:
+		"Streams Claude CLI output using Server-Sent Events (SSE). Provides real-time streaming of Claude's response with session management and usage tracking. Event types: session (session ID), text (streaming content), result (final usage stats), error (errors), done (stream complete).",
+	tags: ["Streaming"],
+	security: [{ BearerAuth: [] }],
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: streamRequestSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			description: "SSE stream with real-time Claude CLI output",
+			content: {
+				"text/event-stream": {
+					schema: z.string(),
+				},
+			},
+		},
+		400: {
+			description: "Validation error",
+			content: {
+				"application/json": {
+					schema: errorResponseSchema,
+				},
+			},
+		},
+		401: {
+			description: "Missing authorization header",
+			content: {
+				"application/json": {
+					schema: z.object({ error: z.string() }),
+				},
+			},
+		},
+		403: {
+			description: "Invalid API key",
+			content: {
+				"application/json": {
+					schema: z.object({ error: z.string() }),
+				},
+			},
+		},
+	},
+});

--- a/packages/gateway/src/openapi/paths.ts
+++ b/packages/gateway/src/openapi/paths.ts
@@ -38,6 +38,46 @@ registry.registerPath({
 	},
 });
 
+// GET /docs (no auth required)
+registry.registerPath({
+	method: "get",
+	path: "/docs",
+	summary: "API documentation",
+	description:
+		"Interactive API documentation powered by Scalar. No authentication required.",
+	tags: ["Documentation"],
+	responses: {
+		200: {
+			description: "HTML page with interactive API documentation",
+			content: {
+				"text/html": {
+					schema: z.string(),
+				},
+			},
+		},
+	},
+});
+
+// GET /openapi.yaml (no auth required)
+registry.registerPath({
+	method: "get",
+	path: "/openapi.yaml",
+	summary: "OpenAPI specification",
+	description:
+		"Raw OpenAPI 3.1 specification in YAML format. No authentication required.",
+	tags: ["Documentation"],
+	responses: {
+		200: {
+			description: "OpenAPI specification in YAML format",
+			content: {
+				"text/yaml": {
+					schema: z.string(),
+				},
+			},
+		},
+	},
+});
+
 // POST /generate-text
 registry.registerPath({
 	method: "post",

--- a/packages/gateway/src/openapi/schemas.ts
+++ b/packages/gateway/src/openapi/schemas.ts
@@ -1,0 +1,40 @@
+import {
+	OpenAPIRegistry,
+	extendZodWithOpenApi,
+} from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import {
+	errorResponseSchema,
+	generateObjectRequestSchema,
+	generateObjectResponseSchema,
+	generateTextRequestSchema,
+	generateTextResponseSchema,
+	healthResponseSchema,
+	streamRequestSchema,
+	usageInfoSchema,
+} from "../types.js";
+
+// Extend Zod with OpenAPI methods
+extendZodWithOpenApi(z);
+
+export const registry = new OpenAPIRegistry();
+
+// Register request schemas
+registry.register("GenerateTextRequest", generateTextRequestSchema);
+registry.register("GenerateObjectRequest", generateObjectRequestSchema);
+registry.register("StreamRequest", streamRequestSchema);
+
+// Register response schemas
+registry.register("UsageInfo", usageInfoSchema);
+registry.register("GenerateTextResponse", generateTextResponseSchema);
+registry.register("GenerateObjectResponse", generateObjectResponseSchema);
+registry.register("ErrorResponse", errorResponseSchema);
+registry.register("HealthResponse", healthResponseSchema);
+
+// Register security scheme
+registry.registerComponent("securitySchemes", "BearerAuth", {
+	type: "http",
+	scheme: "bearer",
+	description:
+		"API key for authentication. Generate with: openssl rand -hex 32",
+});

--- a/packages/gateway/src/routes/docs.ts
+++ b/packages/gateway/src/routes/docs.ts
@@ -6,12 +6,13 @@ import { Router } from "express";
 const router = Router();
 
 // Resolve path relative to dist directory (compiled output)
+// Cache at module load to avoid disk I/O on every request
 const specPath = resolve(__dirname, "../../../../docs/openapi.yaml");
+const specCache = readFileSync(specPath, "utf-8");
 
 // Serve raw OpenAPI spec
 router.get("/openapi.yaml", (_req, res) => {
-	const spec = readFileSync(specPath, "utf-8");
-	res.type("text/yaml").send(spec);
+	res.type("text/yaml").send(specCache);
 });
 
 // Serve Scalar API reference

--- a/packages/gateway/src/routes/docs.ts
+++ b/packages/gateway/src/routes/docs.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { apiReference } from "@scalar/express-api-reference";
+import { Router } from "express";
+
+const router = Router();
+
+// Resolve path relative to dist directory (compiled output)
+const specPath = resolve(__dirname, "../../../../docs/openapi.yaml");
+
+// Serve raw OpenAPI spec
+router.get("/openapi.yaml", (_req, res) => {
+	const spec = readFileSync(specPath, "utf-8");
+	res.type("text/yaml").send(spec);
+});
+
+// Serve Scalar API reference
+router.use(
+	"/docs",
+	apiReference({
+		url: "/openapi.yaml",
+		theme: "deepSpace",
+	}),
+);
+
+export default router;

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -36,44 +36,62 @@ export type GenerateTextRequest = z.infer<typeof generateTextRequestSchema>;
 export type GenerateObjectRequest = z.infer<typeof generateObjectRequestSchema>;
 export type StreamRequest = z.infer<typeof streamRequestSchema>;
 
-// Response types
-export interface UsageInfo {
-	inputTokens: number;
-	outputTokens: number;
-	totalTokens: number;
-}
+// Response schemas
+export const usageInfoSchema = z.object({
+	inputTokens: z.number(),
+	outputTokens: z.number(),
+	totalTokens: z.number(),
+});
 
-export interface GenerateTextResponse {
-	text: string;
-	usage: UsageInfo;
-	sessionId: string;
-}
+export const generateTextResponseSchema = z.object({
+	text: z.string(),
+	usage: usageInfoSchema,
+	sessionId: z.string(),
+});
 
-export interface GenerateObjectResponse {
-	object: unknown;
-	rawText: string;
-	usage: UsageInfo;
-	sessionId: string;
-}
+export const generateObjectResponseSchema = z.object({
+	object: z.unknown(),
+	rawText: z.string(),
+	usage: usageInfoSchema,
+	sessionId: z.string(),
+});
 
 /**
  * Error codes used by the Claude Code wrapper.
  * Shared between ErrorResponse and ClaudeCliError for type safety.
  */
-export type ErrorCode =
-	| "VALIDATION_ERROR"
-	| "INTERNAL_ERROR"
-	| "UNKNOWN_ERROR"
-	| "TIMEOUT_ERROR"
-	| "CLI_EXIT_ERROR"
-	| "SPAWN_ERROR"
-	| "PARSE_ERROR";
+export const errorCodeSchema = z.enum([
+	"VALIDATION_ERROR",
+	"INTERNAL_ERROR",
+	"UNKNOWN_ERROR",
+	"TIMEOUT_ERROR",
+	"CLI_EXIT_ERROR",
+	"SPAWN_ERROR",
+	"PARSE_ERROR",
+]);
 
-export interface ErrorResponse {
-	error: string;
-	code: ErrorCode;
-	rawText?: string;
-}
+export const errorResponseSchema = z.object({
+	error: z.string(),
+	code: errorCodeSchema,
+	rawText: z.string().optional(),
+});
+
+export const healthResponseSchema = z.object({
+	status: z.enum(["healthy", "unhealthy"]),
+	claudeCli: z.enum(["available", "unavailable"]),
+	timestamp: z.string(),
+	error: z.string().optional(),
+});
+
+// Response types (derived from schemas)
+export type UsageInfo = z.infer<typeof usageInfoSchema>;
+export type GenerateTextResponse = z.infer<typeof generateTextResponseSchema>;
+export type GenerateObjectResponse = z.infer<
+	typeof generateObjectResponseSchema
+>;
+export type ErrorCode = z.infer<typeof errorCodeSchema>;
+export type ErrorResponse = z.infer<typeof errorResponseSchema>;
+export type HealthResponse = z.infer<typeof healthResponseSchema>;
 
 // Claude CLI output structure (from --output-format json)
 export interface ClaudeCliOutput {


### PR DESCRIPTION
## Summary

- Generate an OpenAPI 3.1 specification deterministically from Zod schemas
- Add `@asteasolutions/zod-to-openapi@7.3.4` for schema-to-OpenAPI conversion
- Convert response interfaces to Zod schemas for full type coverage
- Output spec to `docs/openapi.yaml` with CI verification

## Changes

- **deps**: Add `@asteasolutions/zod-to-openapi@7.3.4` and `yaml`
- **types**: Convert `UsageInfo`, `GenerateTextResponse`, `GenerateObjectResponse`, `ErrorResponse` interfaces to Zod schemas; add `healthResponseSchema`
- **openapi**: New `src/openapi/` directory with registry, paths, and generator
- **scripts**: Add `openapi:generate` and `openapi:check` commands
- **ci**: Add verification step to ensure spec stays in sync with code
- **tests**: Add 8 unit tests for OpenAPI generation

## Endpoints Documented

| Endpoint | Auth | Description |
|----------|------|-------------|
| `GET /health` | No | Health check |
| `POST /generate-text` | Yes | Text generation |
| `POST /generate-object` | Yes | Structured JSON generation |
| `POST /stream` | Yes | SSE streaming |

## Test plan

- [x] All 80 unit tests pass
- [x] All 5 e2e tests pass
- [x] `bun run openapi:generate` produces valid YAML
- [x] `bun run openapi:check` passes (spec is up to date)
- [x] CI workflow validates spec on PRs

Closes #17