### PR TITLE
fix(docker): consolidate dev service into single build+image service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ name: koine
 services:
   koine:
     image: ghcr.io/pattern-zones-co/koine:${KOINE_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
       - "127.0.0.1:${GATEWAY_PORT:-3100}:3100"
     environment:
@@ -31,37 +34,6 @@ services:
       - ALL
     # Note: read_only disabled because Claude CLI needs to write to /home/bun/.claude.json
     # Other security hardening (no-new-privileges, cap_drop) remains in place
-    read_only: false
-    tmpfs:
-      - /tmp:mode=1777,size=100m
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3100/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
-  # Local development service - builds from source
-  koine-dev:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    profiles:
-      - dev
-    ports:
-      - "127.0.0.1:${GATEWAY_PORT:-3100}:3100"
-    environment:
-      PORT: 3100
-      HOME: /home/bun
-      CLAUDE_CODE_GATEWAY_API_KEY: ${CLAUDE_CODE_GATEWAY_API_KEY:-}
-      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-    volumes:
-      - koine-data:/home/bun/.claude
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
     read_only: false
     tmpfs:
       - /tmp:mode=1777,size=100m

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -34,13 +34,13 @@ Available version formats:
 
 ## Building from Source
 
-Build from source using the dev profile:
+Build from source instead of pulling the pre-built image:
 
 ```bash
-docker compose --profile dev up --build
+docker compose up --build
 ```
 
-This uses the `koine-dev` service which builds locally from the Dockerfile. See [CONTRIBUTING.md](../CONTRIBUTING.md) for development setup.
+This builds locally from the Dockerfile. See [CONTRIBUTING.md](../CONTRIBUTING.md) for development setup.
 
 ## Configuration
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -49,17 +49,7 @@
 		"node": "22.21.1",
 		"bun": "1.3.3"
 	},
-	"keywords": [
-		"claude",
-		"claude-code",
-		"anthropic",
-		"ai",
-		"gateway",
-		"api"
-	],
+	"keywords": ["claude", "claude-code", "anthropic", "ai", "gateway", "api"],
 	"license": "SEE LICENSE IN LICENSE",
-	"files": [
-		"dist",
-		"README.md"
-	]
+	"files": ["dist", "README.md"]
 }

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -42,17 +42,7 @@
 		"node": "22.21.1",
 		"bun": "1.3.3"
 	},
-	"keywords": [
-		"claude",
-		"claude-code",
-		"anthropic",
-		"ai",
-		"sdk",
-		"gateway"
-	],
+	"keywords": ["claude", "claude-code", "anthropic", "ai", "sdk", "gateway"],
 	"license": "SEE LICENSE IN LICENSE",
-	"files": [
-		"dist",
-		"README.md"
-	]
+	"files": ["dist", "README.md"]
 }


### PR DESCRIPTION
## Summary
- Removes the separate `koine-dev` service that caused port conflicts when running with `--profile dev`
- Consolidates into a single service with both `image:` and `build:` directives
- Updates documentation to reflect new usage

## Usage
- `docker compose up` → pulls pre-built image
- `docker compose up --build` → builds from local source

## Test plan
- [x] Verified `docker compose up` uses pre-built image
- [x] Verified `docker compose up --build` builds from source
- [x] Validated config with `docker compose config`