### PR TITLE
feat(ci): add automated PyPI publishing for Python SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Format with Biome
         run: bunx @biomejs/biome@1.9.4 format --write .
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Format Python SDK with Ruff
+        run: uvx ruff@0.14.10 format packages/sdks/python
+
       - name: Commit formatting changes
         run: |
           git config user.name "github-actions[bot]"
@@ -183,3 +189,28 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public --provenance
         working-directory: packages/sdks/typescript
+
+  publish-pypi:
+    needs: [release-please, ci-checks]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build distribution
+        run: uv build
+        working-directory: packages/sdks/python
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/sdks/python/dist/

--- a/packages/sdks/python/pyproject.toml
+++ b/packages/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "koine-sdk"
-version = "2.0.0"
+version = "1.1.6"
 description = "Python SDK for Koine gateway"
 readme = "README.md"
 license = "MIT"

--- a/packages/sdks/python/src/koine_sdk/__init__.py
+++ b/packages/sdks/python/src/koine_sdk/__init__.py
@@ -17,7 +17,9 @@ Example:
     print(result.text)
 """
 
-__version__ = "2.0.0"
+# x-release-please-start-version
+__version__ = "1.1.6"
+# x-release-please-end
 
 # Client factory (primary API)
 from .client import KoineClient, create_koine

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,13 @@
 			"include-component-in-tag": false,
 			"extra-files": [
 				"packages/gateway/package.json",
-				"packages/sdks/typescript/package.json"
+				"packages/sdks/typescript/package.json",
+				{
+					"type": "toml",
+					"path": "packages/sdks/python/pyproject.toml",
+					"jsonpath": "$.project.version"
+				},
+				"packages/sdks/python/src/koine_sdk/__init__.py"
 			]
 		}
 	},


### PR DESCRIPTION
## Summary
- Add `publish-pypi` job to release workflow using trusted publishing (OIDC)
- Add Ruff formatting to `format-release-pr` job using `uvx` (mirrors `bunx` pattern for Biome)
- Sync Python SDK version with release-please via TOML jsonpath
- Add version markers to `__init__.py` for automatic version bumping

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Add `uvx ruff` formatting + `publish-pypi` job |
| `release-please-config.json` | Add Python SDK files to extra-files for version sync |
| `packages/sdks/python/pyproject.toml` | Sync version to 1.1.6 |
| `packages/sdks/python/src/koine_sdk/__init__.py` | Add version markers |

## Test plan
- [ ] Merge PR to trigger release-please
- [ ] Verify release PR includes Python SDK version bumps
- [ ] Verify format-release-pr formats Python files with Ruff
- [ ] On release, verify publish-pypi job runs successfully
- [ ] Verify package appears on PyPI with correct version