### PR TITLE
docs: update SDK docs for 2.0 breaking changes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,8 @@ curl -X POST http://localhost:3100/generate-text \
 #### TypeScript SDK
 
 ```bash
-npm install @patternzones/koine-sdk
+bun add @patternzones/koine-sdk
+# or: npm install @patternzones/koine-sdk
 ```
 
 ```typescript
@@ -68,11 +69,12 @@ console.log(result.text);
 #### Python SDK
 
 ```bash
-pip install koine-sdk
+uv pip install koine-sdk
+# or: pip install koine-sdk
 ```
 
 ```python
-from koine_sdk import generate_text, KoineConfig
+from koine_sdk import KoineConfig, create_koine
 
 config = KoineConfig(
     base_url="http://localhost:3100",
@@ -80,7 +82,8 @@ config = KoineConfig(
     timeout=300.0,
 )
 
-result = await generate_text(config, prompt="Hello!")
+koine = create_koine(config)
+result = await koine.generate_text(prompt="Hello!")
 print(result.text)
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,11 +35,25 @@ koine/
 │   │           ├── generate.ts      # /generate-text, /generate-object
 │   │           ├── stream.ts        # /stream (SSE)
 │   │           └── health.ts        # /health
-│   └── sdks/typescript/             # TypeScript SDK
-│       └── src/
-│           ├── client.ts            # generateText, streamText, generateObject
-│           ├── types.ts             # Type definitions
-│           └── errors.ts            # KoineError
+│   └── sdks/
+│       ├── typescript/              # TypeScript SDK
+│       │   └── src/
+│       │       ├── index.ts         # Public exports
+│       │       ├── client.ts        # createKoine factory, KoineClient
+│       │       ├── text.ts          # generateText implementation
+│       │       ├── object.ts        # generateObject implementation
+│       │       ├── stream/          # streamText implementation (SSE)
+│       │       ├── types.ts         # Type definitions
+│       │       └── errors.ts        # KoineError
+│       └── python/                  # Python SDK
+│           └── src/koine_sdk/
+│               ├── __init__.py      # Public exports
+│               ├── client.py        # create_koine factory, KoineClient
+│               ├── text.py          # generate_text implementation
+│               ├── object.py        # generate_object implementation
+│               ├── stream/          # stream_text implementation (SSE)
+│               ├── types.py         # Type definitions
+│               └── errors.py        # KoineError
 ├── claude-assets/                   # Skills and commands
 ├── docs/
 ├── Dockerfile

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -5,13 +5,15 @@
 ### TypeScript
 
 ```bash
-npm install @patternzones/koine-sdk
+bun add @patternzones/koine-sdk
+# or: npm install @patternzones/koine-sdk
 ```
 
 ### Python
 
 ```bash
-pip install koine-sdk
+uv pip install koine-sdk
+# or: pip install koine-sdk
 ```
 
 ## Configuration
@@ -32,7 +34,7 @@ const config: KoineConfig = {
 ### Python
 
 ```python
-from koine_sdk import KoineConfig
+from koine_sdk import KoineConfig, create_koine
 
 config = KoineConfig(
     base_url="http://localhost:3100",
@@ -40,6 +42,8 @@ config = KoineConfig(
     timeout=300.0,  # optional, default 5 min
     model="sonnet",  # optional default model
 )
+
+koine = create_koine(config)
 ```
 
 ## Text Generation
@@ -63,10 +67,7 @@ console.log(result.sessionId);
 ### Python
 
 ```python
-from koine_sdk import generate_text
-
-result = await generate_text(
-    config,
+result = await koine.generate_text(
     prompt="Explain quantum computing",
     system="You are a helpful teacher",  # optional
     session_id="continue-conversation",  # optional
@@ -99,9 +100,7 @@ const usage = await result.usage;
 ### Python
 
 ```python
-from koine_sdk import stream_text
-
-async with stream_text(config, prompt="Write a short story") as result:
+async with koine.stream_text(prompt="Write a short story") as result:
     async for chunk in result.text_stream:
         print(chunk, end="", flush=True)
 
@@ -135,15 +134,13 @@ console.log(result.object);  // typed as { name: string, age: number, email: str
 
 ```python
 from pydantic import BaseModel
-from koine_sdk import generate_object
 
 class Person(BaseModel):
     name: str
     age: int
     email: str
 
-result = await generate_object(
-    config,
+result = await koine.generate_object(
     prompt="Extract: John is 30, email john@example.com",
     schema=Person,
 )
@@ -171,10 +168,10 @@ try {
 ### Python
 
 ```python
-from koine_sdk import KoineError, generate_text
+from koine_sdk import KoineError
 
 try:
-    result = await generate_text(config, prompt="Hello")
+    result = await koine.generate_text(prompt="Hello")
 except KoineError as e:
     print(f"Error [{e.code}]: {e}")
     if e.raw_text:
@@ -196,9 +193,8 @@ const result2 = await generateText(config, {
 ### Python
 
 ```python
-result1 = await generate_text(config, prompt="My name is Alice")
-result2 = await generate_text(
-    config,
+result1 = await koine.generate_text(prompt="My name is Alice")
+result2 = await koine.generate_text(
     prompt="What is my name?",
     session_id=result1.session_id,
 )

--- a/packages/sdks/python/README.md
+++ b/packages/sdks/python/README.md
@@ -16,14 +16,15 @@ See [Docker Deployment](https://github.com/pattern-zones-co/koine/blob/main/docs
 ## Installation
 
 ```bash
-pip install koine-sdk
+uv pip install koine-sdk
+# or: pip install koine-sdk
 ```
 
 ## Quick Start
 
 ```python
 import asyncio
-from koine_sdk import KoineConfig, generate_text
+from koine_sdk import KoineConfig, create_koine
 
 config = KoineConfig(
     base_url="http://localhost:3100",
@@ -32,7 +33,8 @@ config = KoineConfig(
 )
 
 async def main():
-    result = await generate_text(config, prompt="Hello, how are you?")
+    koine = create_koine(config)
+    result = await koine.generate_text(prompt="Hello, how are you?")
     print(result.text)
 
 asyncio.run(main())
@@ -40,27 +42,36 @@ asyncio.run(main())
 
 ## Features
 
-- **Text Generation** — `generate_text()` for simple prompts
-- **Streaming** — `stream_text()` with async iterators
-- **Structured Output** — `generate_object()` with Pydantic schema validation
+- **Text Generation** — `koine.generate_text()` for simple prompts
+- **Streaming** — `koine.stream_text()` with async iterators
+- **Structured Output** — `koine.generate_object()` with Pydantic schema validation
 - **Type Safety** — Full type hints for all requests and responses
 - **Error Handling** — `KoineError` class with error codes
 
 ## API
 
-### Functions
+### Client Factory
 
-| Function | Description |
-|----------|-------------|
-| `generate_text(config, *, prompt, system?, session_id?)` | Generate text from a prompt |
-| `stream_text(config, *, prompt, system?, session_id?)` | Stream text via Server-Sent Events |
-| `generate_object(config, *, prompt, schema, system?, session_id?)` | Extract structured data using a Pydantic model |
+```python
+koine = create_koine(config)
+```
+
+Creates a client instance with the given configuration. The config is validated once at creation time.
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `koine.generate_text(*, prompt, system?, session_id?)` | Generate text from a prompt |
+| `koine.stream_text(*, prompt, system?, session_id?)` | Stream text via Server-Sent Events |
+| `koine.generate_object(*, prompt, schema, system?, session_id?)` | Extract structured data using a Pydantic model |
 
 ### Types
 
 | Type | Description |
 |------|-------------|
 | `KoineConfig` | Client configuration (base_url, auth_key, timeout, model) |
+| `KoineClient` | Client interface returned by `create_koine()` |
 | `GenerateTextResult` | Text generation response with usage stats |
 | `GenerateObjectResult[T]` | Object extraction response (generic over schema) |
 | `StreamTextResult` | Streaming result with async iterators and futures |

--- a/packages/sdks/typescript/README.md
+++ b/packages/sdks/typescript/README.md
@@ -16,7 +16,8 @@ See [Docker Deployment](https://github.com/pattern-zones-co/koine/blob/main/docs
 ## Installation
 
 ```bash
-npm install @patternzones/koine-sdk
+bun add @patternzones/koine-sdk
+# or: npm install @patternzones/koine-sdk
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Prefer `uv`/`bun` over `pip`/`npm` in installation examples (with alternatives shown)
- Fix Python SDK examples to use `create_koine()` factory pattern instead of standalone functions that were never exported
- Update `architecture.md` with Python SDK structure

## Files Changed

- `docs/README.md` - Installation and quick start examples
- `docs/sdk-guide.md` - All Python examples updated to factory pattern
- `docs/architecture.md` - Added Python SDK to project structure
- `packages/sdks/python/README.md` - Quick start, features, and API docs
- `packages/sdks/typescript/README.md` - Installation example

## Test plan

- [ ] Verify Python examples work with `from koine_sdk import create_koine`
- [ ] Verify TypeScript examples still work with direct imports