### PR TITLE
Prefer ANTHROPIC_API_KEY over OAuth token when both are set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,8 @@
 # Generate a secure key with: openssl rand -hex 32
 CLAUDE_CODE_GATEWAY_API_KEY=your-secret-api-key
 
-# Claude authentication (one of these is required)
-# Recommended: Anthropic API key for automation
+# Claude authentication (required)
 ANTHROPIC_API_KEY=
-
-# Alternative: OAuth token (Claude Pro/Max) - for personal testing and development only
-# CLAUDE_CODE_OAUTH_TOKEN=
 
 # Gateway server port (optional, default: 3100)
 GATEWAY_PORT=3100

--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ console.log(result.text);
 >
 > - **Use Docker**: containers provide essential filesystem and process isolation
 > - **Internal networks only**: deploy on VPN or Docker networks, not public internet
-> - **Use API keys for automation**: Anthropic API keys are the recommended authentication method. They operate under the [Commercial Terms](https://www.anthropic.com/legal/commercial-terms) which permit programmatic access.
-> - **OAuth tokens for personal use only**: Claude Pro/Max OAuth tokens are appropriate for personal testing and development. For production or shared deployments, use an API key.
+> - **Use API keys**: Anthropic API keys operate under the [Commercial Terms](https://www.anthropic.com/legal/commercial-terms) which permit programmatic access
 >
-> See [Environment Variables](docs/environment-variables.md#terms-considerations) for details.
+> See [Environment Variables](docs/environment-variables.md) for configuration details.
 
 ## Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       HOME: /home/bun
       # Authentication for the gateway API
       CLAUDE_CODE_GATEWAY_API_KEY: ${CLAUDE_CODE_GATEWAY_API_KEY:-}
-      # Claude auth: ANTHROPIC_API_KEY recommended for automation (see docs/environment-variables.md)
-      # OAuth tokens are appropriate for personal testing and development only
+      # Claude authentication
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
     volumes:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -5,13 +5,7 @@
 | Variable | Description |
 |----------|-------------|
 | `CLAUDE_CODE_GATEWAY_API_KEY` | Bearer token for gateway API requests |
-
-## Claude Authentication (one required)
-
-| Variable | Description |
-|----------|-------------|
-| `ANTHROPIC_API_KEY` | Anthropic API key (recommended for automation) |
-| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (Claude Pro/Max). See [Terms Considerations](#terms-considerations). |
+| `ANTHROPIC_API_KEY` | Anthropic API key for Claude authentication |
 
 ## Optional
 
@@ -28,10 +22,6 @@ ANTHROPIC_API_KEY=sk-ant-...
 GATEWAY_PORT=3100
 ```
 
-## Terms Considerations
+## Terms
 
-**API keys** are the recommended authentication method for Koine and automation use cases. They operate under [Anthropic's Commercial Terms](https://www.anthropic.com/legal/commercial-terms) which explicitly permit programmatic access.
-
-**OAuth tokens** (Claude Pro/Max subscriptions) are appropriate for personal testing and development only. For production or shared deployments, use an API key.
-
-If both are set, the OAuth token takes precedence. For automation, set only `ANTHROPIC_API_KEY`.
+Anthropic API keys operate under [Anthropic's Commercial Terms](https://www.anthropic.com/legal/commercial-terms) which explicitly permit programmatic access.

--- a/packages/gateway/__tests__/cli.test.ts
+++ b/packages/gateway/__tests__/cli.test.ts
@@ -44,23 +44,23 @@ describe("CLI Module", () => {
 			process.env = originalEnv;
 		});
 
-		it("returns process.env when no OAuth token is set", () => {
-			process.env.CLAUDE_CODE_OAUTH_TOKEN = undefined;
-			process.env.ANTHROPIC_API_KEY = "test-api-key";
+		it("returns process.env when no API key is set", () => {
+			process.env.ANTHROPIC_API_KEY = undefined;
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
 
 			const env = buildClaudeEnv();
 
-			expect(env.ANTHROPIC_API_KEY).toBe("test-api-key");
+			expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-token");
 		});
 
-		it("clears ANTHROPIC_API_KEY when OAuth token is present", () => {
-			process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
+		it("clears OAuth token when API key is present", () => {
 			process.env.ANTHROPIC_API_KEY = "test-api-key";
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
 
 			const env = buildClaudeEnv();
 
-			expect(env.ANTHROPIC_API_KEY).toBeUndefined();
-			expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-token");
+			expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+			expect(env.ANTHROPIC_API_KEY).toBe("test-api-key");
 		});
 	});
 

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -5,7 +5,7 @@ import type { ClaudeCliOutput, ErrorCode, UsageInfo } from "./types.js";
 
 /**
  * Builds environment variables for Claude CLI with auth precedence.
- * Prefers OAuth token (Max subscription) over API key when both are present.
+ * Prefers API key over OAuth token when both are present.
  *
  * Also passes through tool proxy variables for Claude skills that need to
  * invoke Inbox Zero API tools.
@@ -15,9 +15,9 @@ export function buildClaudeEnv(options?: {
 }): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 
-	// Prefer OAuth token for Max subscribers over API key
-	if (env.CLAUDE_CODE_OAUTH_TOKEN) {
-		env.ANTHROPIC_API_KEY = undefined;
+	// Prefer API key for automation; OAuth only for personal testing
+	if (env.ANTHROPIC_API_KEY) {
+		env.CLAUDE_CODE_OAUTH_TOKEN = undefined;
 	}
 
 	// Pass through tool proxy variables for Claude skills

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -7,6 +7,11 @@ import type { ClaudeCliOutput, ErrorCode, UsageInfo } from "./types.js";
  * Builds environment variables for Claude CLI with auth precedence.
  * Prefers API key over OAuth token when both are present.
  *
+ * CLAUDE_CODE_OAUTH_TOKEN is an undocumented fallback for personal testing only.
+ * OAuth tokens (Claude Pro/Max) operate under Anthropic's Consumer Terms which
+ * prohibit automated access. Use ANTHROPIC_API_KEY for all automation.
+ * See: https://www.anthropic.com/legal/consumer-terms
+ *
  * Also passes through tool proxy variables for Claude skills that need to
  * invoke Inbox Zero API tools.
  */
@@ -15,7 +20,8 @@ export function buildClaudeEnv(options?: {
 }): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 
-	// Prefer API key for automation; OAuth only for personal testing
+	// API key takes precedence - OAuth is undocumented fallback for personal testing only.
+	// OAuth tokens may violate Anthropic's Consumer Terms for automated use.
 	if (env.ANTHROPIC_API_KEY) {
 		env.CLAUDE_CODE_OAUTH_TOKEN = undefined;
 	}


### PR DESCRIPTION
## Summary

Reverses the auth precedence so `ANTHROPIC_API_KEY` takes priority over `CLAUDE_CODE_OAUTH_TOKEN`, and hides the OAuth option from public documentation.

## Changes

**Implementation (`packages/gateway/src/cli.ts`)**
- Reverse precedence: API key now clears OAuth token (not vice versa)
- Add terms of use warning in JSDoc and inline comments

**Documentation**
- Remove OAuth from all user-facing docs and examples
- OAuth remains functional but undocumented (discoverable only in source code)
- Simplify environment variables docs

## Why

Per Anthropic's Consumer Terms, OAuth tokens (Claude Pro/Max) are not intended for automated access. API keys operate under the Commercial Terms which explicitly permit automation.

## Test plan

- [x] All 83 gateway tests pass
- [x] Pre-commit hooks pass (linting, type checking, secrets scan)

Fixes #61