### PR TITLE
refactor(test): replace setTimeout with deterministic spawn polling

### DIFF
--- a/packages/gateway/__tests__/integration/app.test.ts
+++ b/packages/gateway/__tests__/integration/app.test.ts
@@ -8,7 +8,11 @@
 import { spawn } from "node:child_process";
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createCliResultJson, createMockChildProcess } from "../helpers.js";
+import {
+	afterSpawnCalled,
+	createCliResultJson,
+	createMockChildProcess,
+} from "../helpers.js";
 
 // Set required environment variable BEFORE any imports
 // Using vi.hoisted to ensure this runs at the earliest possible time
@@ -46,11 +50,11 @@ describe("Claude Code Wrapper App (Integration)", () => {
 
 			const responsePromise = request(app).get("/health");
 
-			// Simulate successful claude --version check (50ms for CI reliability)
-			setTimeout(() => {
+			// Simulate successful claude --version check
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -96,14 +100,14 @@ describe("Claude Code Wrapper App (Integration)", () => {
 				.set("Authorization", validAuthHeader)
 				.send({ prompt: "Hello" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(createCliResultJson({ result: "Hi!" })),
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -128,10 +132,10 @@ describe("Claude Code Wrapper App (Integration)", () => {
 
 			const responsePromise = request(app).get("/health");
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -147,14 +151,14 @@ describe("Claude Code Wrapper App (Integration)", () => {
 				.set("Authorization", validAuthHeader)
 				.send({ prompt: "Hello" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(createCliResultJson({ result: "Response" })),
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -176,14 +180,14 @@ describe("Claude Code Wrapper App (Integration)", () => {
 					schema: { type: "object", properties: { name: { type: "string" } } },
 				});
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(createCliResultJson({ result: '{"name": "Test"}' })),
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -202,9 +206,9 @@ describe("Claude Code Wrapper App (Integration)", () => {
 				.set("Authorization", validAuthHeader)
 				.send({ prompt: "Hello" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -224,14 +228,14 @@ describe("Claude Code Wrapper App (Integration)", () => {
 				.set("Content-Type", "application/json")
 				.send({ prompt: "Test prompt" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(createCliResultJson({ result: "Response" })),
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 

--- a/packages/gateway/__tests__/integration/sdk.integration.test.ts
+++ b/packages/gateway/__tests__/integration/sdk.integration.test.ts
@@ -21,6 +21,7 @@ import {
 } from "vitest";
 import { z } from "zod";
 import {
+	afterSpawnCalled,
 	createCliResultJson,
 	createMockChildProcess,
 	createStreamAssistantMessage,
@@ -101,8 +102,8 @@ describe("SDK Integration Tests", () => {
 				prompt: "Hello",
 			});
 
-			// Simulate CLI response after a short delay
-			setTimeout(() => {
+			// Simulate CLI response after spawn is called
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(
@@ -115,7 +116,7 @@ describe("SDK Integration Tests", () => {
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const result = await promise;
 
@@ -135,14 +136,14 @@ describe("SDK Integration Tests", () => {
 				prompt: "Hello",
 			});
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(createCliResultJson({ result: "Hi there!" })),
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const result = await promise;
 
@@ -180,7 +181,7 @@ describe("SDK Integration Tests", () => {
 				schema: personSchema,
 			});
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(
@@ -191,7 +192,7 @@ describe("SDK Integration Tests", () => {
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const result = await promise;
 
@@ -220,7 +221,7 @@ describe("SDK Integration Tests", () => {
 				schema: addressSchema,
 			});
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(
@@ -236,7 +237,7 @@ describe("SDK Integration Tests", () => {
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 50);
+			});
 
 			const result = await promise;
 
@@ -256,29 +257,20 @@ describe("SDK Integration Tests", () => {
 
 			// Simulate streaming response using newline-delimited JSON (NDJSON)
 			// Each JSON object must end with a newline for the gateway's line parser
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				// Text chunks (assistant messages with newlines)
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(`${createStreamAssistantMessage("One ")}\n`),
 				);
-			}, 30);
-
-			setTimeout(() => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(`${createStreamAssistantMessage("Two ")}\n`),
 				);
-			}, 60);
-
-			setTimeout(() => {
 				mockProc.stdout.emit(
 					"data",
 					Buffer.from(`${createStreamAssistantMessage("Three")}\n`),
 				);
-			}, 90);
-
-			setTimeout(() => {
 				// Result event (with newline)
 				mockProc.stdout.emit(
 					"data",
@@ -288,7 +280,7 @@ describe("SDK Integration Tests", () => {
 				);
 				mockProc.exitCode = 0;
 				mockProc.emit("close", 0, null);
-			}, 120);
+			});
 
 			const result = await promise;
 
@@ -343,11 +335,11 @@ describe("SDK Integration Tests", () => {
 				prompt: "test",
 			});
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				mockProc.stderr.emit("data", Buffer.from("CLI error occurred"));
 				mockProc.exitCode = 1;
 				mockProc.emit("close", 1, null);
-			}, 50);
+			});
 
 			await expect(promise).rejects.toBeInstanceOf(KoineError);
 		});

--- a/packages/gateway/__tests__/routes/generate.test.ts
+++ b/packages/gateway/__tests__/routes/generate.test.ts
@@ -10,6 +10,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import generateRouter from "../../src/routes/generate.js";
 import {
+	afterSpawnCalled,
 	createCliResultJson,
 	createMockChildProcess,
 	simulateCliError,
@@ -70,7 +71,7 @@ describe("Generate Routes", () => {
 				.send({ prompt: "Hello" });
 
 			// Simulate successful CLI response
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(
 					mockProc,
 					createCliResultJson({
@@ -80,7 +81,7 @@ describe("Generate Routes", () => {
 						session_id: "session-123",
 					}),
 				);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -105,9 +106,9 @@ describe("Generate Routes", () => {
 				.post("/generate-text")
 				.send({ prompt: "Hello", system: "Be helpful" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(mockProc, createCliResultJson({ result: "Hi!" }));
-			}, 50);
+			});
 
 			await responsePromise;
 
@@ -127,9 +128,9 @@ describe("Generate Routes", () => {
 				.post("/generate-text")
 				.send({ prompt: "Hello", model: "haiku" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(mockProc, createCliResultJson({ result: "Hi!" }));
-			}, 50);
+			});
 
 			await responsePromise;
 
@@ -149,9 +150,9 @@ describe("Generate Routes", () => {
 				.post("/generate-text")
 				.send({ prompt: "Hello", sessionId: "session-abc" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(mockProc, createCliResultJson({ result: "Hi!" }));
-			}, 50);
+			});
 
 			await responsePromise;
 
@@ -171,9 +172,9 @@ describe("Generate Routes", () => {
 				.post("/generate-text")
 				.send({ prompt: "Hello" });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliError(mockProc, "Rate limit exceeded", 1);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -225,14 +226,14 @@ describe("Generate Routes", () => {
 				.post("/generate-object")
 				.send({ prompt: "Generate a person", schema: validSchema });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(
 					mockProc,
 					createCliResultJson({
 						result: '{"name": "Alice", "age": 30}',
 					}),
 				);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -252,14 +253,14 @@ describe("Generate Routes", () => {
 				.post("/generate-object")
 				.send({ prompt: "Generate a person", schema: validSchema });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(
 					mockProc,
 					createCliResultJson({
 						result: '```json\n{"name": "Bob"}\n```',
 					}),
 				);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -276,14 +277,14 @@ describe("Generate Routes", () => {
 				.post("/generate-object")
 				.send({ prompt: "Generate a person", schema: validSchema });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(
 					mockProc,
 					createCliResultJson({
 						result: 'Here is the result: {"name": "Charlie"} - done!',
 					}),
 				);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -301,14 +302,14 @@ describe("Generate Routes", () => {
 				.post("/generate-object")
 				.send({ prompt: "Generate a list", schema: arraySchema });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(
 					mockProc,
 					createCliResultJson({
 						result: '["one", "two", "three"]',
 					}),
 				);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -325,14 +326,14 @@ describe("Generate Routes", () => {
 				.post("/generate-object")
 				.send({ prompt: "Generate a person", schema: validSchema });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(
 					mockProc,
 					createCliResultJson({
 						result: "This is not valid JSON at all",
 					}),
 				);
-			}, 50);
+			});
 
 			const res = await responsePromise;
 
@@ -350,12 +351,12 @@ describe("Generate Routes", () => {
 				.post("/generate-object")
 				.send({ prompt: "Generate a person", schema: validSchema });
 
-			setTimeout(() => {
+			afterSpawnCalled(mockSpawn, () => {
 				simulateCliSuccess(
 					mockProc,
 					createCliResultJson({ result: '{"name": "Test"}' }),
 				);
-			}, 50);
+			});
 
 			await responsePromise;
 

--- a/packages/gateway/__tests__/routes/health.test.ts
+++ b/packages/gateway/__tests__/routes/health.test.ts
@@ -9,25 +9,7 @@ import express from "express";
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import healthRouter from "../../src/routes/health.js";
-import { createMockChildProcess } from "../helpers.js";
-
-/** Schedule callback after spawn is called (non-blocking) */
-function afterSpawnCalled(
-	mockSpawn: ReturnType<typeof vi.fn>,
-	callback: () => void,
-): void {
-	let iterations = 0;
-	const check = () => {
-		if (mockSpawn.mock.calls.length > 0) {
-			callback();
-		} else if (iterations++ < 1000) {
-			setTimeout(check, 1);
-		} else {
-			throw new Error("Timeout waiting for spawn to be called");
-		}
-	};
-	check();
-}
+import { afterSpawnCalled, createMockChildProcess } from "../helpers.js";
 
 // Mock node:child_process
 vi.mock("node:child_process", () => ({


### PR DESCRIPTION
## Summary
- Extracted `afterSpawnCalled` helper from `health.test.ts` to shared `helpers.ts`
- Replaced all `setTimeout` patterns with deterministic spawn polling across test files
- Eliminates flaky test timing issues in CI environments

## Changes
| File | Replacements |
|------|-------------|
| `helpers.ts` | Added `afterSpawnCalled` helper function |
| `health.test.ts` | Imported helper from shared module |
| `stream.test.ts` | 16 replacements |
| `generate.test.ts` | 11 replacements |
| `app.test.ts` | 8 replacements |
| `sdk.integration.test.ts` | 6 replacements |

## How it works
The `afterSpawnCalled` helper polls every 1ms until `mockSpawn` has been called, then executes the callback. This eliminates race conditions where `setTimeout(50)` might fire before or after the actual spawn call depending on CI load.

```typescript
// Before - timing-dependent and flaky
setTimeout(() => {
  mockProc.emit("close", 0, null);
}, 50);

// After - deterministic
afterSpawnCalled(mockSpawn, () => {
  mockProc.emit("close", 0, null);
});
```

Closes #29

## Test plan
- [x] All 83 tests pass locally
- [x] Pre-commit hooks pass (Biome, TypeScript, secret scanning)