### PR TITLE
feat(gateway): add concurrency limits for request handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ ANTHROPIC_API_KEY=
 
 # Gateway server port (optional, default: 3100)
 GATEWAY_PORT=3100
+
+# Concurrency limits (optional)
+# KOINE_MAX_STREAMING_CONCURRENT=3
+# KOINE_MAX_NONSTREAMING_CONCURRENT=5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,7 @@ That's it. We'll figure out the details together.
 
 Looking for ideas? Here are improvements we'd love help with:
 
-- **Concurrency limits** - Limit concurrent CLI subprocesses to prevent resource exhaustion
-- **Request queuing** - Queue requests when concurrency limit is reached instead of rejecting
-- **Rate limiting** - Per-key request throttling
+- ~~**Concurrency limits** - Limit concurrent CLI subprocesses to prevent resource exhaustion~~ ✅ Done!
 - **Response caching** - Cache identical prompts
 - ~~**Python SDK** - Port the TypeScript SDK to Python ([#2](https://github.com/pattern-zones-co/koine/issues/2))~~ ✅ Done!
 - **Docker Hardened Images** - Migrate to zero-CVE base images ([#1](https://github.com/pattern-zones-co/koine/issues/1))

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ See [Docker Deployment](docs/docker-deployment.md) for docker-compose, version p
 - **TypeScript & Python SDKs**: full type safety and async support
 - **Extensible**: add custom [skills and slash commands](docs/skills-and-commands.md)
 - **Docker-first**: containerized deployment with security isolation
+- **Concurrency limits**: configurable limits prevent resource exhaustion (clients handle retries)
 
 ## SDK Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       # Claude authentication
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
+      # Concurrency limits
+      KOINE_MAX_STREAMING_CONCURRENT: ${KOINE_MAX_STREAMING_CONCURRENT:-3}
+      KOINE_MAX_NONSTREAMING_CONCURRENT: ${KOINE_MAX_NONSTREAMING_CONCURRENT:-5}
     volumes:
       # Named volume for Claude CLI data
       - koine-data:/home/bun/.claude

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,3 +25,17 @@ curl -H "Authorization: Bearer $CLAUDE_CODE_GATEWAY_API_KEY" \
 ## Sessions
 
 Omit `sessionId` to start new. Include previous `sessionId` to continue conversation.
+
+## Concurrency Limits
+
+The gateway limits concurrent requests to prevent resource exhaustion. When limits are exceeded:
+
+- **Status**: `429 Too Many Requests`
+- **Header**: `Retry-After: 5`
+- **Body**: `{ "error": "Concurrency limit exceeded", "code": "CONCURRENCY_LIMIT_ERROR" }`
+
+Default limits:
+- `/stream`: 3 concurrent requests
+- `/generate-text`, `/generate-object`: 5 concurrent requests
+
+See [Environment Variables](environment-variables.md) to configure limits.

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -46,6 +46,18 @@ This builds locally from the Dockerfile. See [CONTRIBUTING.md](../CONTRIBUTING.m
 
 See [`docker-compose.yml`](../docker-compose.yml) and [`Dockerfile`](../Dockerfile) in the repo root. These can be adapted for your orchestration setup.
 
+### Concurrency Limits
+
+The gateway limits concurrent requests to prevent resource exhaustion. Configure via environment variables:
+
+```yaml
+environment:
+  KOINE_MAX_STREAMING_CONCURRENT: 3      # default
+  KOINE_MAX_NONSTREAMING_CONCURRENT: 5   # default
+```
+
+See [Environment Variables](environment-variables.md) for all configuration options.
+
 ## Security
 
 The included configuration uses:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -12,6 +12,14 @@
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GATEWAY_PORT` | `3100` | HTTP server port |
+| `KOINE_MAX_STREAMING_CONCURRENT` | `3` | Maximum concurrent `/stream` requests |
+| `KOINE_MAX_NONSTREAMING_CONCURRENT` | `5` | Maximum concurrent `/generate-text` and `/generate-object` requests |
+
+### Concurrency Limits
+
+The gateway limits concurrent requests to prevent resource exhaustion. Streaming requests (which are long-running) have a separate, lower limit than non-streaming requests.
+
+When limits are exceeded, the gateway returns `429 Too Many Requests` with a `Retry-After` header. Clients should implement retry logic with exponential backoff.
 
 ## Example
 
@@ -20,6 +28,10 @@
 CLAUDE_CODE_GATEWAY_API_KEY=your-secure-api-key
 ANTHROPIC_API_KEY=sk-ant-...
 GATEWAY_PORT=3100
+
+# Optional: adjust concurrency limits (defaults shown)
+# KOINE_MAX_STREAMING_CONCURRENT=3
+# KOINE_MAX_NONSTREAMING_CONCURRENT=5
 ```
 
 ## Terms

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -161,6 +161,7 @@ components:
             - CLI_EXIT_ERROR
             - SPAWN_ERROR
             - PARSE_ERROR
+            - CONCURRENCY_LIMIT_ERROR
         rawText:
           type: string
       required:
@@ -183,6 +184,36 @@ components:
           type: string
         error:
           type: string
+        concurrency:
+          type: object
+          properties:
+            streaming:
+              type: object
+              properties:
+                active:
+                  type: integer
+                  minimum: 0
+                limit:
+                  type: integer
+                  minimum: 0
+              required:
+                - active
+                - limit
+            nonStreaming:
+              type: object
+              properties:
+                active:
+                  type: integer
+                  minimum: 0
+                limit:
+                  type: integer
+                  minimum: 0
+              required:
+                - active
+                - limit
+          required:
+            - streaming
+            - nonStreaming
       required:
         - status
         - claudeCli
@@ -213,6 +244,36 @@ paths:
                     type: string
                   error:
                     type: string
+                  concurrency:
+                    type: object
+                    properties:
+                      streaming:
+                        type: object
+                        properties:
+                          active:
+                            type: integer
+                            minimum: 0
+                          limit:
+                            type: integer
+                            minimum: 0
+                        required:
+                          - active
+                          - limit
+                      nonStreaming:
+                        type: object
+                        properties:
+                          active:
+                            type: integer
+                            minimum: 0
+                          limit:
+                            type: integer
+                            minimum: 0
+                        required:
+                          - active
+                          - limit
+                    required:
+                      - streaming
+                      - nonStreaming
                 required:
                   - status
                   - claudeCli
@@ -234,6 +295,36 @@ paths:
                     type: string
                   error:
                     type: string
+                  concurrency:
+                    type: object
+                    properties:
+                      streaming:
+                        type: object
+                        properties:
+                          active:
+                            type: integer
+                            minimum: 0
+                          limit:
+                            type: integer
+                            minimum: 0
+                        required:
+                          - active
+                          - limit
+                      nonStreaming:
+                        type: object
+                        properties:
+                          active:
+                            type: integer
+                            minimum: 0
+                          limit:
+                            type: integer
+                            minimum: 0
+                        required:
+                          - active
+                          - limit
+                    required:
+                      - streaming
+                      - nonStreaming
                 required:
                   - status
                   - claudeCli

--- a/packages/gateway/__tests__/concurrency.test.ts
+++ b/packages/gateway/__tests__/concurrency.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for concurrency limiting module (concurrency.ts).
+ *
+ * Tests the acquire/release semaphore logic and the withConcurrencyLimit wrapper.
+ */
+
+import { spawn } from "node:child_process";
+import express, { type Request, type Response } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	acquireSlot,
+	getConfig,
+	getStatus,
+	releaseSlot,
+	resetState,
+	setConfig,
+	withConcurrencyLimit,
+} from "../src/concurrency.js";
+import generateRouter from "../src/routes/generate.js";
+import {
+	afterSpawnCalled,
+	createCliResultJson,
+	createMockChildProcess,
+	simulateCliSuccess,
+} from "./helpers.js";
+
+// Mock node:child_process
+vi.mock("node:child_process", () => ({
+	spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(spawn);
+
+describe("Concurrency Module", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetState();
+		// Reset to default limits
+		setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 5 });
+	});
+
+	describe("acquireSlot / releaseSlot", () => {
+		it("acquires slot when under limit", () => {
+			expect(acquireSlot("streaming")).toBe(true);
+			expect(acquireSlot("nonStreaming")).toBe(true);
+		});
+
+		it("returns false when at streaming limit", () => {
+			setConfig({ maxStreamingConcurrent: 2, maxNonStreamingConcurrent: 5 });
+
+			expect(acquireSlot("streaming")).toBe(true);
+			expect(acquireSlot("streaming")).toBe(true);
+			expect(acquireSlot("streaming")).toBe(false);
+		});
+
+		it("returns false when at non-streaming limit", () => {
+			setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 2 });
+
+			expect(acquireSlot("nonStreaming")).toBe(true);
+			expect(acquireSlot("nonStreaming")).toBe(true);
+			expect(acquireSlot("nonStreaming")).toBe(false);
+		});
+
+		it("releases slot allowing subsequent acquire", () => {
+			setConfig({ maxStreamingConcurrent: 1, maxNonStreamingConcurrent: 5 });
+
+			expect(acquireSlot("streaming")).toBe(true);
+			expect(acquireSlot("streaming")).toBe(false);
+
+			releaseSlot("streaming");
+
+			expect(acquireSlot("streaming")).toBe(true);
+		});
+
+		it("streaming and non-streaming have independent limits", () => {
+			setConfig({ maxStreamingConcurrent: 1, maxNonStreamingConcurrent: 1 });
+
+			expect(acquireSlot("streaming")).toBe(true);
+			expect(acquireSlot("nonStreaming")).toBe(true);
+
+			// Both at limit now
+			expect(acquireSlot("streaming")).toBe(false);
+			expect(acquireSlot("nonStreaming")).toBe(false);
+
+			// Release streaming, non-streaming still at limit
+			releaseSlot("streaming");
+			expect(acquireSlot("streaming")).toBe(true);
+			expect(acquireSlot("nonStreaming")).toBe(false);
+		});
+
+		it("release does not go below zero", () => {
+			releaseSlot("streaming");
+			releaseSlot("streaming");
+			releaseSlot("streaming");
+
+			const status = getStatus();
+			expect(status.streaming.active).toBe(0);
+		});
+	});
+
+	describe("getStatus", () => {
+		it("returns current active counts and limits", () => {
+			setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 5 });
+
+			acquireSlot("streaming");
+			acquireSlot("streaming");
+			acquireSlot("nonStreaming");
+
+			const status = getStatus();
+			expect(status).toEqual({
+				streaming: { active: 2, limit: 3 },
+				nonStreaming: { active: 1, limit: 5 },
+			});
+		});
+	});
+
+	describe("getConfig / setConfig", () => {
+		it("returns current configuration", () => {
+			setConfig({ maxStreamingConcurrent: 10, maxNonStreamingConcurrent: 20 });
+
+			const config = getConfig();
+			expect(config.maxStreamingConcurrent).toBe(10);
+			expect(config.maxNonStreamingConcurrent).toBe(20);
+		});
+
+		it("allows partial config updates", () => {
+			setConfig({ maxStreamingConcurrent: 10, maxNonStreamingConcurrent: 20 });
+			setConfig({ maxStreamingConcurrent: 5 });
+
+			const config = getConfig();
+			expect(config.maxStreamingConcurrent).toBe(5);
+			expect(config.maxNonStreamingConcurrent).toBe(20);
+		});
+	});
+
+	describe("withConcurrencyLimit", () => {
+		function createTestApp() {
+			const app = express();
+			app.use(express.json());
+
+			app.post(
+				"/test",
+				withConcurrencyLimit(
+					"nonStreaming",
+					async (_req: Request, res: Response) => {
+						res.json({ success: true });
+					},
+				),
+			);
+
+			return app;
+		}
+
+		it("allows request when under limit", async () => {
+			setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 5 });
+			const app = createTestApp();
+
+			const res = await request(app).post("/test").send({});
+
+			expect(res.status).toBe(200);
+			expect(res.body).toEqual({ success: true });
+		});
+
+		it("returns 429 when at limit", async () => {
+			setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 0 });
+			const app = createTestApp();
+
+			const res = await request(app).post("/test").send({});
+
+			expect(res.status).toBe(429);
+			expect(res.body).toMatchObject({
+				error: "Concurrency limit exceeded",
+				code: "CONCURRENCY_LIMIT_ERROR",
+			});
+			expect(res.headers["retry-after"]).toBe("5");
+		});
+
+		it("releases slot after response completes", async () => {
+			setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 1 });
+			const app = createTestApp();
+
+			// First request should succeed
+			const res1 = await request(app).post("/test").send({});
+			expect(res1.status).toBe(200);
+
+			// Slot should be released, second request should also succeed
+			const res2 = await request(app).post("/test").send({});
+			expect(res2.status).toBe(200);
+		});
+	});
+
+	describe("Integration with generate routes", () => {
+		function createTestApp() {
+			const app = express();
+			app.use(express.json());
+			app.use(generateRouter);
+			return app;
+		}
+
+		it("returns 429 when limit is zero (verifies wrapper is applied)", async () => {
+			// Set limit to 0 - any request should be rejected immediately
+			setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 0 });
+
+			const app = createTestApp();
+
+			const res = await request(app)
+				.post("/generate-text")
+				.send({ prompt: "Hello" });
+
+			expect(res.status).toBe(429);
+			expect(res.body.code).toBe("CONCURRENCY_LIMIT_ERROR");
+			expect(res.headers["retry-after"]).toBe("5");
+		});
+
+		it("allows request when under limit (verifies wrapper is applied)", async () => {
+			setConfig({ maxStreamingConcurrent: 3, maxNonStreamingConcurrent: 5 });
+
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const app = createTestApp();
+
+			const p = request(app).post("/generate-text").send({ prompt: "Hello" });
+			afterSpawnCalled(mockSpawn, () => {
+				simulateCliSuccess(mockProc, createCliResultJson());
+			});
+			const res = await p;
+
+			expect(res.status).toBe(200);
+		});
+	});
+});

--- a/packages/gateway/src/concurrency.ts
+++ b/packages/gateway/src/concurrency.ts
@@ -1,0 +1,141 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+
+// Configuration from environment
+export interface ConcurrencyConfig {
+	maxStreamingConcurrent: number;
+	maxNonStreamingConcurrent: number;
+}
+
+export type RequestType = "streaming" | "nonStreaming";
+
+// Load configuration from environment
+const config: ConcurrencyConfig = {
+	maxStreamingConcurrent: Number.parseInt(
+		process.env.KOINE_MAX_STREAMING_CONCURRENT || "3",
+		10,
+	),
+	maxNonStreamingConcurrent: Number.parseInt(
+		process.env.KOINE_MAX_NONSTREAMING_CONCURRENT || "5",
+		10,
+	),
+};
+
+// State (module-scoped - safe because Bun is single-threaded for JS execution)
+let streamingCount = 0;
+let nonStreamingCount = 0;
+
+/**
+ * Attempt to acquire a concurrency slot.
+ * Returns true if slot acquired, false if at limit.
+ */
+export function acquireSlot(type: RequestType): boolean {
+	if (type === "streaming") {
+		if (streamingCount >= config.maxStreamingConcurrent) {
+			return false;
+		}
+		streamingCount++;
+		return true;
+	}
+	if (nonStreamingCount >= config.maxNonStreamingConcurrent) {
+		return false;
+	}
+	nonStreamingCount++;
+	return true;
+}
+
+/**
+ * Release a concurrency slot.
+ */
+export function releaseSlot(type: RequestType): void {
+	if (type === "streaming") {
+		streamingCount = Math.max(0, streamingCount - 1);
+	} else {
+		nonStreamingCount = Math.max(0, nonStreamingCount - 1);
+	}
+}
+
+/**
+ * Get current concurrency status for health endpoint.
+ */
+export function getStatus(): {
+	streaming: { active: number; limit: number };
+	nonStreaming: { active: number; limit: number };
+} {
+	return {
+		streaming: {
+			active: streamingCount,
+			limit: config.maxStreamingConcurrent,
+		},
+		nonStreaming: {
+			active: nonStreamingCount,
+			limit: config.maxNonStreamingConcurrent,
+		},
+	};
+}
+
+/**
+ * Reset state for testing.
+ */
+export function resetState(): void {
+	streamingCount = 0;
+	nonStreamingCount = 0;
+}
+
+/**
+ * Get current configuration (useful for testing).
+ */
+export function getConfig(): ConcurrencyConfig {
+	return { ...config };
+}
+
+/**
+ * Set configuration (useful for testing).
+ */
+export function setConfig(newConfig: Partial<ConcurrencyConfig>): void {
+	if (newConfig.maxStreamingConcurrent !== undefined) {
+		config.maxStreamingConcurrent = newConfig.maxStreamingConcurrent;
+	}
+	if (newConfig.maxNonStreamingConcurrent !== undefined) {
+		config.maxNonStreamingConcurrent = newConfig.maxNonStreamingConcurrent;
+	}
+}
+
+/**
+ * Wrap an Express request handler with concurrency limiting.
+ * Returns 429 if at limit, otherwise executes handler and releases slot on completion.
+ */
+export function withConcurrencyLimit(
+	type: RequestType,
+	handler: RequestHandler,
+): RequestHandler {
+	return async (req: Request, res: Response, next: NextFunction) => {
+		const acquired = acquireSlot(type);
+		if (!acquired) {
+			res.setHeader("Retry-After", "5");
+			return res.status(429).json({
+				error: "Concurrency limit exceeded",
+				code: "CONCURRENCY_LIMIT_ERROR",
+			});
+		}
+
+		// Track whether we've released to prevent double-release
+		let released = false;
+		const release = () => {
+			if (!released) {
+				released = true;
+				releaseSlot(type);
+			}
+		};
+
+		// Release on any response completion
+		res.on("finish", release);
+		res.on("close", release);
+
+		try {
+			await handler(req, res, next);
+		} catch (error) {
+			release();
+			throw error;
+		}
+	};
+}

--- a/packages/gateway/src/concurrency.ts
+++ b/packages/gateway/src/concurrency.ts
@@ -124,7 +124,8 @@ export function resetState(): void {
 }
 
 /**
- * Get current configuration (useful for testing).
+ * Get current configuration.
+ * Returns a shallow copy to prevent external mutation.
  */
 export function getConfig(): ConcurrencyConfig {
 	return { ...config };

--- a/packages/gateway/src/routes/health.ts
+++ b/packages/gateway/src/routes/health.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { Router } from "express";
+import { getStatus as getConcurrencyStatus } from "../concurrency.js";
 
 const router: Router = Router();
 
@@ -11,11 +12,14 @@ const router: Router = Router();
 router.get("/health", async (_req, res) => {
 	const claudeAvailable = await checkClaudeCliAvailable();
 
+	const concurrency = getConcurrencyStatus();
+
 	if (claudeAvailable) {
 		res.json({
 			status: "healthy",
 			claudeCli: "available",
 			timestamp: new Date().toISOString(),
+			concurrency,
 		});
 	} else {
 		res.status(503).json({
@@ -23,6 +27,7 @@ router.get("/health", async (_req, res) => {
 			claudeCli: "unavailable",
 			timestamp: new Date().toISOString(),
 			error: "Claude CLI not found or not accessible",
+			concurrency,
 		});
 	}
 });

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -68,6 +68,7 @@ export const errorCodeSchema = z.enum([
 	"CLI_EXIT_ERROR",
 	"SPAWN_ERROR",
 	"PARSE_ERROR",
+	"CONCURRENCY_LIMIT_ERROR",
 ]);
 
 export const errorResponseSchema = z.object({
@@ -76,11 +77,22 @@ export const errorResponseSchema = z.object({
 	rawText: z.string().optional(),
 });
 
+const concurrencyPoolSchema = z.object({
+	active: z.number(),
+	limit: z.number(),
+});
+
 export const healthResponseSchema = z.object({
 	status: z.enum(["healthy", "unhealthy"]),
 	claudeCli: z.enum(["available", "unavailable"]),
 	timestamp: z.string(),
 	error: z.string().optional(),
+	concurrency: z
+		.object({
+			streaming: concurrencyPoolSchema,
+			nonStreaming: concurrencyPoolSchema,
+		})
+		.optional(),
 });
 
 // Response types (derived from schemas)

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -77,10 +77,14 @@ export const errorResponseSchema = z.object({
 	rawText: z.string().optional(),
 });
 
-const concurrencyPoolSchema = z.object({
-	active: z.number(),
-	limit: z.number(),
-});
+const concurrencyPoolSchema = z
+	.object({
+		active: z.number().int().nonnegative(),
+		limit: z.number().int().nonnegative(),
+	})
+	.refine((data) => data.active <= data.limit, {
+		message: "active cannot exceed limit",
+	});
 
 export const healthResponseSchema = z.object({
 	status: z.enum(["healthy", "unhealthy"]),

--- a/packages/sdks/python/README.md
+++ b/packages/sdks/python/README.md
@@ -78,6 +78,26 @@ Creates a client instance with the given configuration. The config is validated 
 | `KoineUsage` | Token usage information |
 | `KoineError` | Error class with code and raw_text |
 
+## Error Handling & Retries
+
+The SDK does not automatically retry failed requests. When the gateway returns `429 Too Many Requests` (concurrency limit exceeded), your application should implement retry logic:
+
+```python
+import asyncio
+from koine_sdk import KoineError
+
+async def generate_with_retry(prompt: str, max_retries: int = 3):
+    for i in range(max_retries):
+        try:
+            return await koine.generate_text(prompt=prompt)
+        except KoineError as e:
+            if e.code == "CONCURRENCY_LIMIT_ERROR":
+                await asyncio.sleep(1 * (i + 1))  # Exponential backoff
+                continue
+            raise
+    raise Exception("Max retries exceeded")
+```
+
 ## Documentation
 
 See the [SDK Guide](https://github.com/pattern-zones-co/koine/blob/main/docs/sdk-guide.md) for:


### PR DESCRIPTION
## Summary

- Add configurable concurrency limits to prevent resource exhaustion
- Separate pools for streaming (default: 3) and non-streaming (default: 5) requests
- Returns 429 with `Retry-After: 5` header when limits exceeded
- Environment variable configuration: `KOINE_MAX_STREAMING_CONCURRENT`, `KOINE_MAX_NONSTREAMING_CONCURRENT`

## Changes

### Core Implementation
- `packages/gateway/src/concurrency.ts` - Semaphore-based limiter with acquire/release pattern
- `packages/gateway/src/types.ts` - Added `CONCURRENCY_LIMIT_ERROR` code and health schema
- Routes wrapped with `withConcurrencyLimit()` middleware

### Validation & Logging
- Environment variable validation with logged fallbacks for invalid values
- Logging when concurrency limits are hit (warn level)
- Logging when handler errors occur (error level)
- `setConfig()` validates inputs are non-negative integers

### Documentation
- Updated `docs/environment-variables.md`, `docs/api-reference.md`, `docs/sdk-guide.md`
- Added retry handling examples to SDK READMEs
- Updated `CONTRIBUTING.md` roadmap

### Tests (24 new tests)
- Acquire/release slot logic
- Wrapper middleware behavior
- Error handling and slot release
- Integration with generate and stream routes
- Edge cases: slot exhaustion, response events

## Test plan

- [x] `bun run test` - 107 tests pass
- [x] `bun run lint` - No errors
- [x] Manual testing with `docker compose up` and curl