### PR TITLE
feat(gateway): use native --json-schema for structured output

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -37,13 +37,14 @@ components:
           type: string
         sessionId:
           type: string
-        maxTokens:
-          type: number
         model:
           type: string
         userEmail:
           type: string
           format: email
+        maxTokens:
+          type: integer
+          exclusiveMinimum: 0
       required:
         - prompt
     GenerateObjectRequest:
@@ -53,18 +54,19 @@ components:
           type: string
         prompt:
           type: string
-        schema:
-          type: object
-          additionalProperties: {}
         sessionId:
           type: string
-        maxTokens:
-          type: number
         model:
           type: string
         userEmail:
           type: string
           format: email
+        schema:
+          type: object
+          additionalProperties: {}
+        maxTokens:
+          type: integer
+          exclusiveMinimum: 0
       required:
         - prompt
         - schema
@@ -88,11 +90,14 @@ components:
       type: object
       properties:
         inputTokens:
-          type: number
+          type: integer
+          minimum: 0
         outputTokens:
-          type: number
+          type: integer
+          minimum: 0
         totalTokens:
-          type: number
+          type: integer
+          minimum: 0
       required:
         - inputTokens
         - outputTokens
@@ -106,11 +111,14 @@ components:
           type: object
           properties:
             inputTokens:
-              type: number
+              type: integer
+              minimum: 0
             outputTokens:
-              type: number
+              type: integer
+              minimum: 0
             totalTokens:
-              type: number
+              type: integer
+              minimum: 0
           required:
             - inputTokens
             - outputTokens
@@ -131,11 +139,14 @@ components:
           type: object
           properties:
             inputTokens:
-              type: number
+              type: integer
+              minimum: 0
             outputTokens:
-              type: number
+              type: integer
+              minimum: 0
             totalTokens:
-              type: number
+              type: integer
+              minimum: 0
           required:
             - inputTokens
             - outputTokens
@@ -375,13 +386,14 @@ paths:
                   type: string
                 sessionId:
                   type: string
-                maxTokens:
-                  type: number
                 model:
                   type: string
                 userEmail:
                   type: string
                   format: email
+                maxTokens:
+                  type: integer
+                  exclusiveMinimum: 0
               required:
                 - prompt
       responses:
@@ -398,11 +410,14 @@ paths:
                     type: object
                     properties:
                       inputTokens:
-                        type: number
+                        type: integer
+                        minimum: 0
                       outputTokens:
-                        type: number
+                        type: integer
+                        minimum: 0
                       totalTokens:
-                        type: number
+                        type: integer
+                        minimum: 0
                     required:
                       - inputTokens
                       - outputTokens
@@ -487,18 +502,19 @@ paths:
                   type: string
                 prompt:
                   type: string
-                schema:
-                  type: object
-                  additionalProperties: {}
                 sessionId:
                   type: string
-                maxTokens:
-                  type: number
                 model:
                   type: string
                 userEmail:
                   type: string
                   format: email
+                schema:
+                  type: object
+                  additionalProperties: {}
+                maxTokens:
+                  type: integer
+                  exclusiveMinimum: 0
               required:
                 - prompt
                 - schema
@@ -517,11 +533,14 @@ paths:
                     type: object
                     properties:
                       inputTokens:
-                        type: number
+                        type: integer
+                        minimum: 0
                       outputTokens:
-                        type: number
+                        type: integer
+                        minimum: 0
                       totalTokens:
-                        type: number
+                        type: integer
+                        minimum: 0
                     required:
                       - inputTokens
                       - outputTokens

--- a/packages/gateway/__tests__/cli.test.ts
+++ b/packages/gateway/__tests__/cli.test.ts
@@ -140,6 +140,24 @@ describe("CLI Module", () => {
 			);
 		});
 
+		it("includes --json-schema when jsonSchema option is provided", async () => {
+			const mockProc = createMockChildProcess();
+			mockSpawn.mockReturnValue(mockProc as never);
+
+			const schema = {
+				type: "object",
+				properties: { name: { type: "string" } },
+			};
+
+			executeClaudeCli({ prompt: "Test", jsonSchema: schema });
+
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"claude",
+				expect.arrayContaining(["--json-schema", JSON.stringify(schema)]),
+				expect.any(Object),
+			);
+		});
+
 		it("throws ClaudeCliError on non-zero exit code", async () => {
 			const mockProc = createMockChildProcess();
 			mockSpawn.mockReturnValue(mockProc as never);
@@ -252,8 +270,7 @@ describe("CLI Module", () => {
 				JSON.stringify({
 					type: "result",
 					result: "Hello",
-					total_tokens_in: 5,
-					total_tokens_out: 5,
+					usage: { input_tokens: 5, output_tokens: 5 },
 				}),
 			);
 

--- a/packages/gateway/__tests__/helpers.ts
+++ b/packages/gateway/__tests__/helpers.ts
@@ -83,9 +83,11 @@ export function createCliResultOutput(
 		type: "result",
 		result: "Hello! How can I help you today?",
 		session_id: "test-session-123",
-		total_tokens_in: 10,
-		total_tokens_out: 15,
-		cost_usd: 0.001,
+		usage: {
+			input_tokens: 10,
+			output_tokens: 15,
+		},
+		total_cost_usd: 0.001,
 		duration_ms: 500,
 		...overrides,
 	};
@@ -118,15 +120,16 @@ export function createStreamAssistantMessage(text: string): string {
 export function createStreamResultMessage(
 	overrides: Partial<{
 		session_id: string;
-		total_tokens_in: number;
-		total_tokens_out: number;
+		usage: { input_tokens: number; output_tokens: number };
 	}> = {},
 ): string {
 	return JSON.stringify({
 		type: "result",
 		session_id: "test-session-123",
-		total_tokens_in: 10,
-		total_tokens_out: 15,
+		usage: {
+			input_tokens: 10,
+			output_tokens: 15,
+		},
 		...overrides,
 	});
 }

--- a/packages/gateway/__tests__/integration/sdk.integration.test.ts
+++ b/packages/gateway/__tests__/integration/sdk.integration.test.ts
@@ -109,8 +109,7 @@ describe("SDK Integration Tests", () => {
 					Buffer.from(
 						createCliResultJson({
 							result: "Hello from Claude!",
-							total_tokens_in: 10,
-							total_tokens_out: 5,
+							usage: { input_tokens: 10, output_tokens: 5 },
 						}),
 					),
 				);

--- a/packages/gateway/__tests__/routes/stream.test.ts
+++ b/packages/gateway/__tests__/routes/stream.test.ts
@@ -148,8 +148,7 @@ describe("Stream Route", () => {
 					"data",
 					Buffer.from(
 						`${createStreamResultMessage({
-							total_tokens_in: 10,
-							total_tokens_out: 20,
+							usage: { input_tokens: 10, output_tokens: 20 },
 						})}\n`,
 					),
 				);
@@ -398,8 +397,7 @@ describe("Stream Route", () => {
 				const resultMsg = JSON.stringify({
 					type: "result",
 					session_id: "buffered-session",
-					total_tokens_in: 5,
-					total_tokens_out: 10,
+					usage: { input_tokens: 5, output_tokens: 10 },
 				});
 				mockProc.stdout.emit("data", Buffer.from(resultMsg));
 				// Close without newline - buffer should be processed in close handler

--- a/packages/gateway/src/routes/generate.ts
+++ b/packages/gateway/src/routes/generate.ts
@@ -36,8 +36,7 @@ router.post(
 				return;
 			}
 
-			const { prompt, system, sessionId, maxTokens, model, userEmail } =
-				parseResult.data;
+			const { prompt, system, sessionId, model, userEmail } = parseResult.data;
 
 			logger.info("generate-text", {
 				model: model || "default",
@@ -50,7 +49,6 @@ router.post(
 					prompt,
 					system,
 					sessionId,
-					maxTokens,
 					model,
 					userEmail,
 				});
@@ -92,7 +90,7 @@ router.post(
 				return;
 			}
 
-			const { prompt, system, schema, sessionId, maxTokens, model, userEmail } =
+			const { prompt, system, schema, sessionId, model, userEmail } =
 				parseResult.data;
 
 			logger.info("generate-object", {
@@ -106,13 +104,12 @@ router.post(
 					prompt,
 					system,
 					sessionId,
-					maxTokens,
 					model,
 					userEmail,
 					jsonSchema: schema,
 				});
 
-				// Parse the JSON response (guaranteed valid by constrained decoding)
+				// Parse the JSON response (CLI constrained decoding enforces valid JSON)
 				const parsedObject = parseJsonResponse(result.text);
 
 				res.json({
@@ -130,7 +127,7 @@ router.post(
 
 /**
  * Parses JSON from Claude's response.
- * With --json-schema constrained decoding, the output is guaranteed valid JSON.
+ * With --json-schema constrained decoding, the CLI enforces valid JSON output.
  */
 function parseJsonResponse(text: string): unknown {
 	return JSON.parse(text);

--- a/packages/gateway/src/routes/stream.ts
+++ b/packages/gateway/src/routes/stream.ts
@@ -23,8 +23,10 @@ interface StreamAssistantMessage {
 interface StreamResultMessage {
 	type: "result";
 	session_id?: string;
-	total_tokens_in?: number;
-	total_tokens_out?: number;
+	usage?: {
+		input_tokens?: number;
+		output_tokens?: number;
+	};
 }
 
 /**
@@ -216,14 +218,14 @@ router.post(
 						}
 					} else if (parsed.type === "result") {
 						// Final result
+						const inputTokens = parsed.usage?.input_tokens ?? 0;
+						const outputTokens = parsed.usage?.output_tokens ?? 0;
 						safeSendEvent("result", {
 							sessionId: parsed.session_id || currentSessionId,
 							usage: {
-								inputTokens: parsed.total_tokens_in || 0,
-								outputTokens: parsed.total_tokens_out || 0,
-								totalTokens:
-									(parsed.total_tokens_in || 0) +
-									(parsed.total_tokens_out || 0),
+								inputTokens,
+								outputTokens,
+								totalTokens: inputTokens + outputTokens,
 							},
 						});
 					}
@@ -261,14 +263,14 @@ router.post(
 				try {
 					const parsed = JSON.parse(lineBuffer) as StreamMessage;
 					if (parsed.type === "result") {
+						const inputTokens = parsed.usage?.input_tokens ?? 0;
+						const outputTokens = parsed.usage?.output_tokens ?? 0;
 						safeSendEvent("result", {
 							sessionId: parsed.session_id || currentSessionId,
 							usage: {
-								inputTokens: parsed.total_tokens_in || 0,
-								outputTokens: parsed.total_tokens_out || 0,
-								totalTokens:
-									(parsed.total_tokens_in || 0) +
-									(parsed.total_tokens_out || 0),
+								inputTokens,
+								outputTokens,
+								totalTokens: inputTokens + outputTokens,
 							},
 						});
 					}

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -1,47 +1,60 @@
 import { z } from "zod";
 
-// Request schemas
-export const generateTextRequestSchema = z.object({
+// =============================================================================
+// Request Schemas
+// =============================================================================
+
+/**
+ * Base request fields shared across all endpoints.
+ */
+const baseRequestSchema = z.object({
 	system: z.string().optional(),
 	prompt: z.string(),
 	sessionId: z.string().optional(),
-	maxTokens: z.number().optional(),
 	model: z.string().optional(),
 	/** User email for tool proxy access (enables Claude skills to call Inbox Zero tools) */
 	userEmail: z.string().email().optional(),
 });
 
-export const generateObjectRequestSchema = z.object({
-	system: z.string().optional(),
-	prompt: z.string(),
+export const generateTextRequestSchema = baseRequestSchema.extend({
+	/**
+	 * Maximum tokens to generate.
+	 * Note: Not currently used - Claude CLI does not support --max-tokens.
+	 * Kept for API compatibility; use model selection for output control.
+	 */
+	maxTokens: z.number().int().positive().optional(),
+});
+
+export const generateObjectRequestSchema = baseRequestSchema.extend({
 	schema: z.record(z.unknown()),
-	sessionId: z.string().optional(),
-	maxTokens: z.number().optional(),
-	model: z.string().optional(),
-	/** User email for tool proxy access (enables Claude skills to call Inbox Zero tools) */
-	userEmail: z.string().email().optional(),
+	/**
+	 * Maximum tokens to generate.
+	 * Note: Not currently used - Claude CLI does not support --max-tokens.
+	 * Kept for API compatibility; use model selection for output control.
+	 */
+	maxTokens: z.number().int().positive().optional(),
 });
 
-export const streamRequestSchema = z.object({
-	system: z.string().optional(),
-	prompt: z.string(),
-	sessionId: z.string().optional(),
-	model: z.string().optional(),
-	/** User email for tool proxy access (enables Claude skills to call Inbox Zero tools) */
-	userEmail: z.string().email().optional(),
-});
+export const streamRequestSchema = baseRequestSchema;
 
 // Inferred types
 export type GenerateTextRequest = z.infer<typeof generateTextRequestSchema>;
 export type GenerateObjectRequest = z.infer<typeof generateObjectRequestSchema>;
 export type StreamRequest = z.infer<typeof streamRequestSchema>;
 
-// Response schemas
-export const usageInfoSchema = z.object({
-	inputTokens: z.number(),
-	outputTokens: z.number(),
-	totalTokens: z.number(),
-});
+// =============================================================================
+// Response Schemas
+// =============================================================================
+
+export const usageInfoSchema = z
+	.object({
+		inputTokens: z.number().int().nonnegative(),
+		outputTokens: z.number().int().nonnegative(),
+		totalTokens: z.number().int().nonnegative(),
+	})
+	.refine((data) => data.totalTokens === data.inputTokens + data.outputTokens, {
+		message: "totalTokens must equal inputTokens + outputTokens",
+	});
 
 export const generateTextResponseSchema = z.object({
 	text: z.string(),
@@ -109,7 +122,36 @@ export type ErrorCode = z.infer<typeof errorCodeSchema>;
 export type ErrorResponse = z.infer<typeof errorResponseSchema>;
 export type HealthResponse = z.infer<typeof healthResponseSchema>;
 
-// Claude CLI output structure (from --output-format json)
+// =============================================================================
+// CLI Types
+// =============================================================================
+
+/**
+ * Usage info as returned by Claude CLI (snake_case).
+ * Shared across ClaudeCliOutput and streaming messages.
+ */
+export interface CliUsageInfo {
+	input_tokens?: number;
+	output_tokens?: number;
+	cache_creation_input_tokens?: number;
+	cache_read_input_tokens?: number;
+}
+
+/**
+ * Converts CLI usage info (snake_case) to API usage info (camelCase).
+ * Provides consistent calculation with safe defaults for missing values.
+ */
+export function createUsageInfo(cliUsage?: CliUsageInfo): UsageInfo {
+	const inputTokens = cliUsage?.input_tokens ?? 0;
+	const outputTokens = cliUsage?.output_tokens ?? 0;
+	return {
+		inputTokens,
+		outputTokens,
+		totalTokens: inputTokens + outputTokens,
+	};
+}
+
+/** Claude CLI output structure (from --output-format json) */
 export interface ClaudeCliOutput {
 	type: "result" | "error";
 	subtype?: string;
@@ -120,12 +162,7 @@ export interface ClaudeCliOutput {
 	is_error?: boolean;
 	session_id?: string;
 	num_turns?: number;
-	usage?: {
-		input_tokens?: number;
-		output_tokens?: number;
-		cache_creation_input_tokens?: number;
-		cache_read_input_tokens?: number;
-	};
-	// Structured output from --json-schema flag
+	usage?: CliUsageInfo;
+	/** Structured output from --json-schema flag */
 	structured_output?: unknown;
 }

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -120,14 +120,12 @@ export interface ClaudeCliOutput {
 	is_error?: boolean;
 	session_id?: string;
 	num_turns?: number;
-	// New format (Claude CLI 1.0.17+)
 	usage?: {
 		input_tokens?: number;
 		output_tokens?: number;
 		cache_creation_input_tokens?: number;
 		cache_read_input_tokens?: number;
 	};
-	// Legacy format (kept for backwards compatibility)
-	total_tokens_in?: number;
-	total_tokens_out?: number;
+	// Structured output from --json-schema flag
+	structured_output?: unknown;
 }

--- a/packages/sdks/python/uv.lock
+++ b/packages/sdks/python/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "koine-sdk"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Replaces the prompt injection approach for structured JSON output with Claude CLI's native `--json-schema` flag for constrained decoding. This provides model-level enforcement of valid JSON output.

### Main Feature (Issue #66)
- Add `jsonSchema` option to `ClaudeCliOptions`, passed as `--json-schema` CLI flag
- Handle `structured_output` field in CLI response (used when `--json-schema` is provided)
- Simplify `/generate-object` route by removing prompt injection logic

### Code Quality Improvements
- Add warning log when `jsonSchema` provided but `structured_output` missing (helps detect CLI version mismatches)
- Soften "guarantee" language in comments (the guarantee is external to our code)
- Remove legacy CLI output format support (pre-1.0.17 `total_tokens_in/out` fields that were never needed)

### Type Design Improvements
- Extract `CliUsageInfo` interface for shared CLI usage type (was defined inline in 3 places)
- Add `createUsageInfo()` function for consistent CLI→API usage conversion (eliminates duplication)
- Extract `baseRequestSchema` to reduce request schema duplication
- Add `.int().nonnegative()` refinements to `UsageInfo` schema with `totalTokens` consistency check
- Remove unused `outputFormat` field from `ClaudeCliOptions` (always hardcoded to "json")
- Make `rawOutput` non-nullable in `ClaudeCliResult` (we throw on parse failure, never return null)
- Document unused `maxTokens` field (CLI doesn't support `--max-tokens`)

### Test Coverage
- Add tests for `structured_output` code path (5 new tests in cli.test.ts)
- Add E2E tests for `/generate-object` with `structured_output` response (2 new tests)

## Test plan
- [x] All 113 tests pass
- [x] Lint passes
- [x] TypeScript type checking passes
- [x] Manual testing with SDK examples (TypeScript and Python)

Closes #66