### PR TITLE
chore(gateway): remove legacy userEmail/INBOX_ZERO fields

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -39,9 +39,6 @@ components:
           type: string
         model:
           type: string
-        userEmail:
-          type: string
-          format: email
         maxTokens:
           type: integer
           exclusiveMinimum: 0
@@ -58,9 +55,6 @@ components:
           type: string
         model:
           type: string
-        userEmail:
-          type: string
-          format: email
         schema:
           type: object
           properties:
@@ -110,9 +104,6 @@ components:
           type: string
         model:
           type: string
-        userEmail:
-          type: string
-          format: email
       required:
         - prompt
     StreamObjectRequest:
@@ -126,9 +117,6 @@ components:
           type: string
         model:
           type: string
-        userEmail:
-          type: string
-          format: email
         schema:
           type: object
           properties:
@@ -459,9 +447,6 @@ paths:
                   type: string
                 model:
                   type: string
-                userEmail:
-                  type: string
-                  format: email
                 maxTokens:
                   type: integer
                   exclusiveMinimum: 0
@@ -577,9 +562,6 @@ paths:
                   type: string
                 model:
                   type: string
-                userEmail:
-                  type: string
-                  format: email
                 schema:
                   type: object
                   properties:
@@ -722,9 +704,6 @@ paths:
                   type: string
                 model:
                   type: string
-                userEmail:
-                  type: string
-                  format: email
               required:
                 - prompt
       responses:
@@ -795,9 +774,6 @@ paths:
                   type: string
                 model:
                   type: string
-                userEmail:
-                  type: string
-                  format: email
                 schema:
                   type: object
                   properties:

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -16,31 +16,14 @@ import {
  * OAuth tokens (Claude Pro/Max) operate under Anthropic's Consumer Terms which
  * prohibit automated access. Use ANTHROPIC_API_KEY for all automation.
  * See: https://www.anthropic.com/legal/consumer-terms
- *
- * Also passes through tool proxy variables for Claude skills that need to
- * invoke Inbox Zero API tools.
  */
-export function buildClaudeEnv(options?: {
-	userEmail?: string;
-}): NodeJS.ProcessEnv {
+export function buildClaudeEnv(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 
 	// API key takes precedence - OAuth is undocumented fallback for personal testing only.
 	// OAuth tokens may violate Anthropic's Consumer Terms for automated use.
 	if (env.ANTHROPIC_API_KEY) {
 		env.CLAUDE_CODE_OAUTH_TOKEN = undefined;
-	}
-
-	// Pass through tool proxy variables for Claude skills
-	// These enable the inbox-zero-tools skill to invoke the LLM Tool Proxy API
-	if (process.env.INBOX_ZERO_API_URL) {
-		env.INBOX_ZERO_API_URL = process.env.INBOX_ZERO_API_URL;
-	}
-	if (process.env.LLM_TOOL_PROXY_TOKEN) {
-		env.LLM_TOOL_PROXY_TOKEN = process.env.LLM_TOOL_PROXY_TOKEN;
-	}
-	if (options?.userEmail) {
-		env.INBOX_ZERO_USER_EMAIL = options.userEmail;
 	}
 
 	return env;
@@ -57,8 +40,6 @@ export interface ClaudeCliOptions {
 	timeoutMs?: number;
 	/** Model alias (e.g., 'sonnet', 'haiku') or full name */
 	model?: string;
-	/** User email for tool proxy access (enables Claude skills to call Inbox Zero tools) */
-	userEmail?: string;
 	/** JSON schema for constrained decoding (CLI enforces valid JSON output) */
 	jsonSchema?: Record<string, unknown>;
 }
@@ -91,7 +72,7 @@ export async function executeClaudeCli(
 
 		const claude = spawn("claude", args, {
 			stdio: ["pipe", "pipe", "pipe"],
-			env: buildClaudeEnv({ userEmail: options.userEmail }),
+			env: buildClaudeEnv(),
 		});
 
 		// Set up execution timeout

--- a/packages/gateway/src/routes/generate.ts
+++ b/packages/gateway/src/routes/generate.ts
@@ -36,7 +36,7 @@ router.post(
 				return;
 			}
 
-			const { prompt, system, sessionId, model, userEmail } = parseResult.data;
+			const { prompt, system, sessionId, model } = parseResult.data;
 
 			logger.info("generate-text", {
 				model: model || "default",
@@ -50,7 +50,6 @@ router.post(
 					system,
 					sessionId,
 					model,
-					userEmail,
 				});
 
 				res.json({
@@ -90,8 +89,7 @@ router.post(
 				return;
 			}
 
-			const { prompt, system, schema, sessionId, model, userEmail } =
-				parseResult.data;
+			const { prompt, system, schema, sessionId, model } = parseResult.data;
 
 			logger.info("generate-object", {
 				model: model || "default",
@@ -105,7 +103,6 @@ router.post(
 					system,
 					sessionId,
 					model,
-					userEmail,
 					jsonSchema: schema,
 				});
 

--- a/packages/gateway/src/routes/stream-object.ts
+++ b/packages/gateway/src/routes/stream-object.ts
@@ -80,8 +80,7 @@ router.post(
 			return;
 		}
 
-		const { prompt, system, sessionId, model, userEmail, schema } =
-			parseResult.data;
+		const { prompt, system, sessionId, model, schema } = parseResult.data;
 
 		// Set up SSE headers
 		res.setHeader("Content-Type", "text/event-stream");
@@ -113,7 +112,7 @@ router.post(
 
 		const claude = spawn("claude", args, {
 			stdio: ["pipe", "pipe", "pipe"],
-			env: buildClaudeEnv({ userEmail }),
+			env: buildClaudeEnv(),
 		});
 
 		const currentSessionId = sessionId || uuidv4();

--- a/packages/gateway/src/routes/stream.ts
+++ b/packages/gateway/src/routes/stream.ts
@@ -77,7 +77,7 @@ router.post(
 			return;
 		}
 
-		const { prompt, system, sessionId, model, userEmail } = parseResult.data;
+		const { prompt, system, sessionId, model } = parseResult.data;
 
 		// Set up SSE headers
 		res.setHeader("Content-Type", "text/event-stream");
@@ -103,7 +103,7 @@ router.post(
 
 		const claude = spawn("claude", args, {
 			stdio: ["pipe", "pipe", "pipe"],
-			env: buildClaudeEnv({ userEmail }),
+			env: buildClaudeEnv(),
 		});
 
 		const currentSessionId = sessionId || uuidv4();

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -12,8 +12,6 @@ const baseRequestSchema = z.object({
 	prompt: z.string(),
 	sessionId: z.string().optional(),
 	model: z.string().optional(),
-	/** User email for tool proxy access (enables Claude skills to call Inbox Zero tools) */
-	userEmail: z.string().email().optional(),
 });
 
 export const generateTextRequestSchema = baseRequestSchema.extend({


### PR DESCRIPTION
## Summary

- Remove unused `userEmail` field from all API request schemas
- Remove `INBOX_ZERO_*` environment variable handling from `buildClaudeEnv`
- Regenerate OpenAPI spec to reflect the changes

This was leftover code from a prototype email inbox assistant that is no longer active.

## Notes

Neither the TypeScript nor Python SDK exposed `userEmail` in their public API, so this is a **non-breaking change**. The `chore:` commit type ensures release-please will not treat this as a breaking change.

Closes #71