### PR TITLE
chore: fix deprecated poolMatchGlobs warning in vitest config

### DIFF
--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -6,23 +6,45 @@ export default defineConfig({
 		environment: "node",
 		testTimeout: 10000,
 		setupFiles: ["./__tests__/setup.ts"],
-		include: ["__tests__/**/*.test.ts"],
-		exclude: ["__tests__/e2e/**/*.test.ts"],
-		// Use forks pool for tests with shared state (concurrency module, server ports)
-		// to isolate them from parallel execution. Other tests run in threads pool.
-		// This fixes flaky tests from #70 and #72.
-		pool: "threads",
-		poolMatchGlobs: [
-			// Integration tests start actual servers and need isolation
-			["**/__tests__/integration/**", "forks"],
-			// Concurrency tests modify shared module state
-			["**/__tests__/concurrency.test.ts", "forks"],
-		],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "lcov"],
 			include: ["src/**/*.ts"],
 			exclude: ["src/index.ts"], // Entry point tested via integration
 		},
+		// Use projects to run different test sets with different pools.
+		// Integration and concurrency tests need isolation (forks pool)
+		// to avoid flaky tests from shared state (#70, #72).
+		projects: [
+			{
+				extends: true,
+				test: {
+					name: "unit",
+					include: ["__tests__/**/*.test.ts"],
+					exclude: [
+						"__tests__/e2e/**/*.test.ts",
+						"__tests__/integration/**/*.test.ts",
+						"__tests__/concurrency.test.ts",
+					],
+					pool: "threads",
+				},
+			},
+			{
+				extends: true,
+				test: {
+					name: "integration",
+					include: ["__tests__/integration/**/*.test.ts"],
+					pool: "forks",
+				},
+			},
+			{
+				extends: true,
+				test: {
+					name: "concurrency",
+					include: ["__tests__/concurrency.test.ts"],
+					pool: "forks",
+				},
+			},
+		],
 	},
 });


### PR DESCRIPTION
## Summary

- Replaces deprecated `poolMatchGlobs` with `test.projects` API in vitest config
- Creates three named test projects with appropriate pool isolation:
  - `unit` - threads pool (default, fast)
  - `integration` - forks pool (server isolation)
  - `concurrency` - forks pool (shared state isolation)

## Test plan

- [x] All tests pass
- [x] Deprecation warning no longer appears
- [x] Pre-commit hooks pass (lint, typecheck, secrets)

Fixes #77