### PR TITLE
docs: add stream-object documentation across all guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ See [Docker Deployment](docs/docker-deployment.md) for docker-compose, version p
 - **OpenAPI spec**: generate clients for any language
 - **Runnable examples**: copy-paste and go
 - **Text generation**: simple prompts to full responses
-- **Streaming**: real-time Server-Sent Events
-- **Structured output**: type-safe extraction with Zod/Pydantic schemas
+- **Streaming**: real-time Server-Sent Events for text and structured data
+- **Structured output**: type-safe extraction with Zod/Pydantic schemas (batch and streaming)
 - **Session management**: multi-turn conversations with context persistence
 - **TypeScript & Python SDKs**: full type safety and async support
 - **Extensible**: add custom [skills and slash commands](docs/skills-and-commands.md)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,7 +20,8 @@ curl -H "Authorization: Bearer $CLAUDE_CODE_GATEWAY_API_KEY" \
 | GET | `/openapi.yaml` | OpenAPI spec (no auth) |
 | POST | `/generate-text` | Generate text |
 | POST | `/generate-object` | Extract structured JSON |
-| POST | `/stream` | Stream via SSE |
+| POST | `/stream` | Stream text via SSE |
+| POST | `/stream-object` | Stream structured JSON via SSE |
 
 ## Sessions
 
@@ -35,7 +36,7 @@ The gateway limits concurrent requests to prevent resource exhaustion. When limi
 - **Body**: `{ "error": "Concurrency limit exceeded", "code": "CONCURRENCY_LIMIT_ERROR" }`
 
 Default limits:
-- `/stream`: 3 concurrent requests
+- `/stream`, `/stream-object`: 3 concurrent requests
 - `/generate-text`, `/generate-object`: 5 concurrent requests
 
 See [Environment Variables](environment-variables.md) to configure limits.

--- a/packages/sdks/python/README.md
+++ b/packages/sdks/python/README.md
@@ -45,6 +45,7 @@ asyncio.run(main())
 - **Text Generation** — `koine.generate_text()` for simple prompts
 - **Streaming** — `koine.stream_text()` with async iterators
 - **Structured Output** — `koine.generate_object()` with Pydantic schema validation
+- **Streaming Structured Output** — `koine.stream_object()` with partial object streaming
 - **Type Safety** — Full type hints for all requests and responses
 - **Error Handling** — `KoineError` class with error codes
 
@@ -65,6 +66,7 @@ Creates a client instance with the given configuration. The config is validated 
 | `koine.generate_text(*, prompt, system?, session_id?)` | Generate text from a prompt |
 | `koine.stream_text(*, prompt, system?, session_id?)` | Stream text via Server-Sent Events |
 | `koine.generate_object(*, prompt, schema, system?, session_id?)` | Extract structured data using a Pydantic model |
+| `koine.stream_object(*, prompt, schema, system?, session_id?)` | Stream structured data with partial updates |
 
 ### Types
 
@@ -75,6 +77,7 @@ Creates a client instance with the given configuration. The config is validated 
 | `GenerateTextResult` | Text generation response with usage stats |
 | `GenerateObjectResult[T]` | Object extraction response (generic over schema) |
 | `StreamTextResult` | Streaming result with async iterators and futures |
+| `StreamObjectResult[T]` | Streaming object result with partial_object_stream |
 | `KoineUsage` | Token usage information |
 | `KoineError` | Error class with code and raw_text |
 
@@ -118,6 +121,7 @@ uv pip install -e ".[dev]"
 uv run python examples/hello.py           # Basic text generation
 uv run python examples/extract_recipe.py  # Structured output with Pydantic
 uv run python examples/stream.py          # Real-time streaming
+uv run python examples/stream_object.py   # Streaming structured output
 uv run python examples/conversation.py    # Multi-turn sessions
 ```
 

--- a/packages/sdks/python/examples/README.md
+++ b/packages/sdks/python/examples/README.md
@@ -25,6 +25,7 @@ uv pip install -e ".[dev]"
 uv run python examples/hello.py           # Basic text generation
 uv run python examples/extract_recipe.py  # Structured output with Pydantic
 uv run python examples/stream.py          # Real-time streaming
+uv run python examples/stream_object.py   # Streaming structured output
 uv run python examples/conversation.py    # Multi-turn sessions
 ```
 
@@ -35,4 +36,5 @@ uv run python examples/conversation.py    # Multi-turn sessions
 | `hello.py` | Basic text generation |
 | `extract_recipe.py` | Structured output with Pydantic schemas |
 | `stream.py` | Real-time streaming with async iterators |
+| `stream_object.py` | Streaming structured output with partial updates |
 | `conversation.py` | Multi-turn session persistence |

--- a/packages/sdks/typescript/README.md
+++ b/packages/sdks/typescript/README.md
@@ -43,6 +43,7 @@ console.log(result.text);
 - **Text Generation** — `generateText()` for simple prompts
 - **Streaming** — `streamText()` with ReadableStream (async iterable)
 - **Structured Output** — `generateObject()` with Zod schema validation
+- **Streaming Structured Output** — `streamObject()` with partial object streaming
 - **Cancellation** — AbortSignal support for all requests
 - **Type Safety** — Full TypeScript types for all requests and responses
 - **Error Handling** — `KoineError` class with typed error codes
@@ -64,6 +65,7 @@ Creates a client instance with the given configuration. The config is validated 
 | `koine.generateText(options)` | Generate text from a prompt |
 | `koine.streamText(options)` | Stream text via Server-Sent Events |
 | `koine.generateObject(options)` | Extract structured data using a Zod schema |
+| `koine.streamObject(options)` | Stream structured data with partial updates |
 
 ### Types
 
@@ -73,6 +75,7 @@ Creates a client instance with the given configuration. The config is validated 
 | `KoineClient` | Client interface returned by `createKoine()` |
 | `KoineUsage` | Token usage stats (inputTokens, outputTokens, totalTokens) |
 | `KoineStreamResult` | Streaming result with ReadableStream and promises |
+| `KoineStreamObjectResult<T>` | Streaming object result with partialObjectStream |
 | `KoineError` | Error class with typed `code` property |
 | `KoineErrorCode` | Union type of all possible error codes |
 
@@ -113,10 +116,11 @@ Runnable examples are available in the [`examples/`](https://github.com/pattern-
 
 ```bash
 cd packages/sdks/typescript
-bun run example:hello        # Basic text generation
-bun run example:recipe       # Structured output with Zod
-bun run example:stream       # Real-time streaming
-bun run example:conversation # Multi-turn sessions
+bun run example:hello         # Basic text generation
+bun run example:recipe        # Structured output with Zod
+bun run example:stream        # Real-time streaming
+bun run example:stream-object # Streaming structured output
+bun run example:conversation  # Multi-turn sessions
 ```
 
 ## License

--- a/packages/sdks/typescript/examples/README.md
+++ b/packages/sdks/typescript/examples/README.md
@@ -21,10 +21,11 @@
 From the SDK directory (`packages/sdks/typescript`):
 
 ```bash
-bun run example:hello        # Basic text generation
-bun run example:recipe       # Structured output with Zod
-bun run example:stream       # Real-time streaming
-bun run example:conversation # Multi-turn sessions
+bun run example:hello         # Basic text generation
+bun run example:recipe        # Structured output with Zod
+bun run example:stream        # Real-time streaming
+bun run example:stream-object # Streaming structured output
+bun run example:conversation  # Multi-turn sessions
 ```
 
 ## Examples
@@ -34,4 +35,5 @@ bun run example:conversation # Multi-turn sessions
 | `hello.ts` | Basic text generation |
 | `extract-recipe.ts` | Structured output with Zod schemas |
 | `stream.ts` | Real-time streaming with async iterators |
+| `stream-object.ts` | Streaming structured output with partial updates |
 | `conversation.ts` | Multi-turn session persistence |


### PR DESCRIPTION
## Summary

- Add `/stream-object` endpoint to API reference with concurrency limits
- Add "Streaming Structured Output" section to SDK guide with TypeScript/Python examples
- Update README features to mention streaming structured data
- Add `streamObject`/`stream_object` to SDK READMEs (features, methods, types, examples)
- Update architecture diagram and project structure to include stream-object
- Document the prompt injection vs `--json-schema` implementation strategy

## Test plan

- [ ] Verify all markdown links resolve correctly
- [ ] Verify code examples match actual SDK API
- [ ] Check formatting renders correctly on GitHub